### PR TITLE
Add Smart Shelves + Edit Series Toolbar + Series URL Parsing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,100 +1,134 @@
-﻿[*.cs]
+root = true
 
-# CS8600: Converting null literal or possible null value to non-nullable type.
-dotnet_diagnostic.CS8600.severity = none
-csharp_indent_labels = one_less_than_current
-csharp_using_directive_placement = outside_namespace:silent
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_prefer_braces = true:silent
-csharp_style_namespace_declarations = block_scoped:silent
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_top_level_statements = true:silent
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_properties = true:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = false:silent
-
-# CS8601: Possible null reference assignment.
-dotnet_diagnostic.CS8601.severity = none
-
-# CS8602: Dereference of a possibly null reference.
-dotnet_diagnostic.CS8602.severity = none
-
-# CS8604: Possible null reference argument.
-dotnet_diagnostic.CS8604.severity = silent
-
-# CS8767: Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
-dotnet_diagnostic.CS8767.severity = silent
-
-# CS8618: Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-dotnet_diagnostic.CS8618.severity = silent
-
-[*.{cs,vb}]
-#### Naming styles ####
-
-# Naming rules
-
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
-
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
-
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
-
-# Symbol specifications
-
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
-
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
-
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
-
-# Naming styles
-
-dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
-dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-tab_width = 4
+[*]
+indent_style = space
 indent_size = 4
 end_of_line = crlf
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_simplified_interpolation = true:suggestion
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+
+# Flag unused using directives so `dotnet format style --diagnostics IDE0005` can remove them.
+dotnet_diagnostic.IDE0005.severity = warning
+
+# "Can be simplified" family — surface as warnings so they show up in
+# dotnet build / CI, not just as IDE hints. Pure code-style; no runtime
+# behavior change. Auto-fixable with `dotnet format style`.
+
+# Null / coalesce / null-propagation
+dotnet_diagnostic.IDE0029.severity = warning  # Use coalesce expression (non-nullable)
+dotnet_diagnostic.IDE0030.severity = warning  # Use coalesce expression (nullable)
+dotnet_diagnostic.IDE0031.severity = suggestion  # Use null propagation (?.) — silenced in build because `?.` is illegal inside EF expression-tree Selects (CS8072); IDE still surfaces it as a hint for plain delegate code
+dotnet_diagnostic.IDE0041.severity = warning  # Use 'is null' check
+dotnet_diagnostic.IDE0074.severity = warning  # Use compound assignment (??=)
+dotnet_diagnostic.IDE0150.severity = warning  # Prefer null check over type check
+dotnet_diagnostic.IDE0270.severity = warning  # Null check can be simplified
+
+# Object / collection / new() initialization
+dotnet_diagnostic.IDE0017.severity = warning  # Use object initializer
+dotnet_diagnostic.IDE0028.severity = warning  # Use collection initializer
+dotnet_diagnostic.IDE0090.severity = warning  # Simplify 'new' (target-typed)
+dotnet_diagnostic.IDE0300.severity = warning  # Use collection expression []
+dotnet_diagnostic.IDE0301.severity = warning  # Collection expression for empty
+dotnet_diagnostic.IDE0302.severity = warning  # Collection expression for stackalloc
+dotnet_diagnostic.IDE0303.severity = warning  # Collection expression for Create()
+dotnet_diagnostic.IDE0304.severity = warning  # Collection expression for builder
+dotnet_diagnostic.IDE0305.severity = warning  # Collection expression for fluent
+
+# Pattern matching / switch expressions
+dotnet_diagnostic.IDE0019.severity = warning  # Pattern match: 'as' + null check
+dotnet_diagnostic.IDE0020.severity = warning  # Pattern match: 'is' + cast
+dotnet_diagnostic.IDE0066.severity = warning  # Use switch expression
+dotnet_diagnostic.IDE0078.severity = warning  # Use pattern matching
+dotnet_diagnostic.IDE0083.severity = warning  # Use pattern matching ('not' operator)
+
+# Conditional / boolean simplification
+dotnet_diagnostic.IDE0045.severity = warning  # Conditional expression for assignment
+dotnet_diagnostic.IDE0046.severity = warning  # Conditional expression for return
+dotnet_diagnostic.IDE0075.severity = warning  # Simplify conditional expression
+
+# Expression-bodied members (matches CLAUDE.md "use expression-body for single-expression members")
+# Preference is `when_on_single_line` so block bodies are only flagged when the body is a single
+# expression — multi-line members keep their braces without warnings.
+csharp_style_expression_bodied_constructors    = when_on_single_line:warning
+csharp_style_expression_bodied_methods         = when_on_single_line:warning
+csharp_style_expression_bodied_operators       = when_on_single_line:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:warning
+csharp_style_expression_bodied_accessors       = when_on_single_line:warning
+csharp_style_expression_bodied_local_functions = when_on_single_line:warning
+csharp_style_expression_bodied_lambdas         = when_on_single_line:warning
+
+dotnet_diagnostic.IDE0021.severity = warning  # Expression body for constructors
+dotnet_diagnostic.IDE0022.severity = warning  # Expression body for methods
+dotnet_diagnostic.IDE0023.severity = warning  # Expression body for conversion operators
+dotnet_diagnostic.IDE0024.severity = warning  # Expression body for operators
+dotnet_diagnostic.IDE0025.severity = warning  # Expression body for properties
+dotnet_diagnostic.IDE0026.severity = warning  # Expression body for indexers
+dotnet_diagnostic.IDE0027.severity = warning  # Expression body for accessors
+dotnet_diagnostic.IDE0061.severity = warning  # Expression body for local function
+
+# Misc simplifications
+dotnet_diagnostic.IDE0001.severity = warning  # Simplify name (drop redundant qualifier)
+dotnet_diagnostic.IDE0002.severity = warning  # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning  # Remove unnecessary cast
+dotnet_diagnostic.IDE0034.severity = warning  # Simplify default expression
+dotnet_diagnostic.IDE0037.severity = warning  # Use inferred member name (tuples / anonymous types)
+dotnet_diagnostic.IDE0054.severity = warning  # Use compound assignment
+dotnet_diagnostic.IDE0056.severity = warning  # Use index operator (^1)
+dotnet_diagnostic.IDE0057.severity = warning  # Use range operator (..)
+dotnet_diagnostic.IDE0063.severity = warning  # Use simple 'using' statement
+dotnet_diagnostic.IDE0070.severity = warning  # Use HashCode.Combine
+dotnet_diagnostic.IDE0071.severity = warning  # Simplify interpolation
+dotnet_diagnostic.IDE0079.severity = warning  # Remove unnecessary suppression
+dotnet_diagnostic.IDE0080.severity = warning  # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0100.severity = warning  # Remove unnecessary equality
+dotnet_diagnostic.IDE0110.severity = warning  # Remove unnecessary discard
+dotnet_diagnostic.IDE0180.severity = warning  # Use tuple to swap values
+
+# Constants: PascalCase (must be defined before field rules to take priority)
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constants_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+# Private fields (including static): _camelCase
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.private_fields_should_be_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_case.style = underscore_camel_case
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, private_protected
+
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+
+# Private static fields: _camelCase (same convention)
+dotnet_naming_rule.private_static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.private_static_fields_should_be_camel_case.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_should_be_camel_case.style = underscore_camel_case
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private, private_protected
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+# Never use var — always use explicit types
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = false:warning
+csharp_style_var_elsewhere = false:warning
+
+[*.json]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,5 +4,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TieredPGO>true</TieredPGO>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,15 +4,15 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Avalonia">
-    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.5" />
     <PackageVersion Include="Avalonia.Controls.ItemsRepeater" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.3" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.15" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.3" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Headless.NUnit" Version="12.0.3" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.1" />
-    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.6.30" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.18" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Headless.NUnit" Version="12.0.5" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
+    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup Label="Application">
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
@@ -21,25 +21,27 @@
     <PackageVersion Include="GraphQL.Client" Version="6.1.0" />
     <PackageVersion Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
     <PackageVersion Include="MangaAndLightNovelWebScrape" Version="5.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="NLog" Version="6.1.3" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.0.3" />
     <PackageVersion Include="D2Phap.FileWatcherEx" Version="3.0.0" />
-    <PackageVersion Include="Optris.Icons.Avalonia.FontAwesome7" Version="12.0.6" />
+    <PackageVersion Include="Optris.Icons.Avalonia.FontAwesome7" Version="12.0.7" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
-    <PackageVersion Include="System.Drawing.Common" Version="10.0.8" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.9" />
     <PackageVersion Include="TextCopy" Version="6.2.1" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.1.0-dev-292" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="ZLinq" Version="1.5.6" />
   </ItemGroup>
   <ItemGroup Label="Testing">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="NUnit" Version="4.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
   </ItemGroup>
   <ItemGroup Label="Packaging">
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,11 +20,11 @@
     <PackageVersion Include="DynamicData" Version="9.4.31" />
     <PackageVersion Include="GraphQL.Client" Version="6.1.0" />
     <PackageVersion Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
-    <PackageVersion Include="MangaAndLightNovelWebScrape" Version="5.0.2" />
+    <PackageVersion Include="MangaAndLightNovelWebScrape" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="NLog" Version="6.1.3" />
-    <PackageVersion Include="NLog.Extensions.Logging" Version="6.0.3" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
     <PackageVersion Include="D2Phap.FileWatcherEx" Version="3.0.0" />
     <PackageVersion Include="Optris.Icons.Avalonia.FontAwesome7" Version="12.0.7" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />

--- a/RELEASE_NOTES_v2.3.0.md
+++ b/RELEASE_NOTES_v2.3.0.md
@@ -1,0 +1,9 @@
+# Tsundoku v2.3.0
+
+## Changes
+
+- Smart Shelves: save advanced-filter expressions as named chips above the collection — right-click to rename or delete
+- Add Series accepts AniList and MangaDex URLs — paste a link to auto-fill the series ID
+- Add Series title field has a fixed height and scrolls on overflow instead of growing
+- Edit Series header lists every saved title (Romaji, English, Japanese, Native, etc.) on its own row, wrapping cleanly
+- Closing the main window now reliably exits the app when secondary windows are open

--- a/RELEASE_NOTES_v2.3.0.md
+++ b/RELEASE_NOTES_v2.3.0.md
@@ -2,11 +2,13 @@
 
 ## Changes
 
-- Smart Shelves: save advanced-filter expressions as named chips above the collection — click to apply, click again to deselect, right-click to rename or delete
+- Smart Shelves: save advanced-filter expressions as named chips above the collection — click to apply, click again to deselect, right-click to rename, or use the × on each chip to delete
+- Smart Shelves: the active shelf is now visually highlighted so you can tell at a glance which filter is applied
 - Add Series accepts AniList and MangaDex URLs — paste a link to auto-fill the series ID
 - Add Series title field has a fixed height and scrolls on overflow instead of growing
 - Edit Series header lists every saved title (Romaji, English, Japanese, Native, etc.) on its own row, wrapping cleanly
 - Edit Series header now has an icon toolbar: previous/next series navigation, open series link, favorite, refresh, save, mark complete, delete
 - Price Analysis: added All Star Comics (AU), Kings Comics (AU), OK Comics (UK), and MangaMart (US); removed SpeedyHen (retired upstream)
+- Price Analysis: website list now filters to only sites that support the selected region
 - Price Analysis: unreachable sites are now skipped immediately instead of timing out, and per-site failures no longer abort the scrape
-- Closing the main window now reliably exits the app when secondary windows are open
+- Series cards now fade in a touch more gradually so filter and shelf toggles read as a soft cross-fade instead of a hard repaint

--- a/RELEASE_NOTES_v2.3.0.md
+++ b/RELEASE_NOTES_v2.3.0.md
@@ -2,8 +2,11 @@
 
 ## Changes
 
-- Smart Shelves: save advanced-filter expressions as named chips above the collection — right-click to rename or delete
+- Smart Shelves: save advanced-filter expressions as named chips above the collection — click to apply, click again to deselect, right-click to rename or delete
 - Add Series accepts AniList and MangaDex URLs — paste a link to auto-fill the series ID
 - Add Series title field has a fixed height and scrolls on overflow instead of growing
 - Edit Series header lists every saved title (Romaji, English, Japanese, Native, etc.) on its own row, wrapping cleanly
+- Edit Series header now has an icon toolbar: previous/next series navigation, open series link, favorite, refresh, save, mark complete, delete
+- Price Analysis: added All Star Comics (AU), Kings Comics (AU), OK Comics (UK), and MangaMart (US); removed SpeedyHen (retired upstream)
+- Price Analysis: unreachable sites are now skipped immediately instead of timing out, and per-site failures no longer abort the scrape
 - Closing the main window now reliably exits the app when secondary windows are open

--- a/Src/App.axaml.cs
+++ b/Src/App.axaml.cs
@@ -415,6 +415,13 @@ public sealed partial class App : Application
     #endif
         config.LoggingRules.Add(allowWarnPlus);
 
+        // 3) Drop HttpClient request/response chatter — only surface Warn+
+        var dropHttpClientChatter = new LoggingRule("System.Net.Http.HttpClient.*", NLog.LogLevel.Trace, NLog.LogLevel.Info, blackHole)
+        {
+            Final = true
+        };
+        config.LoggingRules.Add(dropHttpClientChatter);
+
         // --- Default catch-alls ---
         config.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Info, NLog.LogLevel.Fatal, asyncWrapper));
     #if DEBUG

--- a/Src/App.axaml.cs
+++ b/Src/App.axaml.cs
@@ -1,7 +1,9 @@
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NLog.Config;
+using NLog.Extensions.Logging;
 using NLog.Targets;
 using NLog.Targets.Wrappers;
 using System.Net;
@@ -20,6 +22,9 @@ public sealed partial class App : Application
     private static readonly Logger LOGGER = LogManager.GetCurrentClassLogger();
     public static Mutex? Mutex { get; set; }
     public static IServiceProvider? ServiceProvider { get; private set; }
+
+    /// <summary>True while the main window is initiating app shutdown so secondary windows can let themselves close.</summary>
+    public static bool IsShuttingDown { get; set; }
 
     public App()
     {
@@ -124,6 +129,7 @@ public sealed partial class App : Application
                     ServiceCollection services = new();
                     ConfigureServices(services);
                     ServiceProvider = services.BuildServiceProvider();
+                    AppLog.SetFactory(ServiceProvider.GetRequiredService<ILoggerFactory>());
 
                     splash.UpdateStatus("Loading user data");
                     IUserService userService = ServiceProvider.GetRequiredService<IUserService>();
@@ -266,6 +272,13 @@ public sealed partial class App : Application
         .SetHandlerLifetime(TimeSpan.FromMinutes(5))
         .AddTypedClient<AniListGraphQLClient>();
 
+        services.AddLogging(builder =>
+        {
+            builder.ClearProviders();
+            builder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
+            ConfigureExtensions.AddNLog(builder);
+        });
+
         services.AddSingleton<BitmapHelper>();
         services.AddSingleton<MangaDex>();
         services.AddSingleton<AniList>();
@@ -386,14 +399,14 @@ public sealed partial class App : Application
         }
 
         // 1) Drop Trace..Info for that namespace, and stop processing
-        var dropLowLevels = new LoggingRule("MangaAndLightNovelWebScrape.*", LogLevel.Trace, LogLevel.Info, blackHole)
+        var dropLowLevels = new LoggingRule("MangaAndLightNovelWebScrape.*", NLog.LogLevel.Trace, NLog.LogLevel.Info, blackHole)
         {
             Final = true
         };
         config.LoggingRules.Add(dropLowLevels);
 
         // 2) Allow Warn..Fatal for that namespace, and stop processing (so it won't hit catch-alls)
-        var allowWarnPlus = new LoggingRule("MangaAndLightNovelWebScrape.*", LogLevel.Warn, LogLevel.Fatal, asyncWrapper)
+        var allowWarnPlus = new LoggingRule("MangaAndLightNovelWebScrape.*", NLog.LogLevel.Warn, NLog.LogLevel.Fatal, asyncWrapper)
         {
             Final = true
         };
@@ -403,9 +416,9 @@ public sealed partial class App : Application
         config.LoggingRules.Add(allowWarnPlus);
 
         // --- Default catch-alls ---
-        config.LoggingRules.Add(new LoggingRule("*", LogLevel.Info, LogLevel.Fatal, asyncWrapper));
+        config.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Info, NLog.LogLevel.Fatal, asyncWrapper));
     #if DEBUG
-        config.LoggingRules.Add(new LoggingRule("*", LogLevel.Debug, LogLevel.Fatal, consoleTarget));
+        config.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Debug, NLog.LogLevel.Fatal, consoleTarget));
     #endif
 
         LogManager.Configuration = config;

--- a/Src/Assets/changelog.json
+++ b/Src/Assets/changelog.json
@@ -119,10 +119,13 @@
   },
   "2.3.0": {
     "changes": [
-      "Smart Shelves: save advanced-filter expressions as named chips above the collection — right-click to rename or delete",
+      "Smart Shelves: save advanced-filter expressions as named chips above the collection — click to apply, click again to deselect, right-click to rename or delete",
       "Add Series accepts AniList and MangaDex URLs — paste a link to auto-fill the series ID",
       "Add Series title field has a fixed height and scrolls on overflow instead of growing",
       "Edit Series header lists every saved title (Romaji, English, Japanese, Native, etc.) on its own row, wrapping cleanly",
+      "Edit Series header now has an icon toolbar: previous/next series navigation, open series link, favorite, refresh, save, mark complete, delete",
+      "Price Analysis: added All Star Comics (AU), Kings Comics (AU), OK Comics (UK), and MangaMart (US); removed SpeedyHen (retired upstream)",
+      "Price Analysis: unreachable sites are now skipped immediately instead of timing out, and per-site failures no longer abort the scrape",
       "Closing the main window now reliably exits the app when secondary windows are open"
     ],
     "actions": []

--- a/Src/Assets/changelog.json
+++ b/Src/Assets/changelog.json
@@ -116,5 +116,15 @@
       "Upgraded Avalonia UI framework to 12.0.3 for upstream rendering fixes and stability improvements"
     ],
     "actions": []
+  },
+  "2.3.0": {
+    "changes": [
+      "Smart Shelves: save advanced-filter expressions as named chips above the collection — right-click to rename or delete",
+      "Add Series accepts AniList and MangaDex URLs — paste a link to auto-fill the series ID",
+      "Add Series title field has a fixed height and scrolls on overflow instead of growing",
+      "Edit Series header lists every saved title (Romaji, English, Japanese, Native, etc.) on its own row, wrapping cleanly",
+      "Closing the main window now reliably exits the app when secondary windows are open"
+    ],
+    "actions": []
   }
 }

--- a/Src/Assets/changelog.json
+++ b/Src/Assets/changelog.json
@@ -119,14 +119,16 @@
   },
   "2.3.0": {
     "changes": [
-      "Smart Shelves: save advanced-filter expressions as named chips above the collection — click to apply, click again to deselect, right-click to rename or delete",
+      "Smart Shelves: save advanced-filter expressions as named chips above the collection — click to apply, click again to deselect, right-click to rename, or use the × on each chip to delete",
+      "Smart Shelves: the active shelf is now visually highlighted so you can tell at a glance which filter is applied",
       "Add Series accepts AniList and MangaDex URLs — paste a link to auto-fill the series ID",
       "Add Series title field has a fixed height and scrolls on overflow instead of growing",
       "Edit Series header lists every saved title (Romaji, English, Japanese, Native, etc.) on its own row, wrapping cleanly",
       "Edit Series header now has an icon toolbar: previous/next series navigation, open series link, favorite, refresh, save, mark complete, delete",
       "Price Analysis: added All Star Comics (AU), Kings Comics (AU), OK Comics (UK), and MangaMart (US); removed SpeedyHen (retired upstream)",
+      "Price Analysis: website list now filters to only sites that support the selected region",
       "Price Analysis: unreachable sites are now skipped immediately instead of timing out, and per-site failures no longer abort the scrape",
-      "Closing the main window now reliably exits the app when secondary windows are open"
+      "Series cards now fade in a touch more gradually so filter and shelf toggles read as a soft cross-fade instead of a hard repaint"
     ],
     "actions": []
   }

--- a/Src/Controls/SeriesCardDisplay.axaml.cs
+++ b/Src/Controls/SeriesCardDisplay.axaml.cs
@@ -74,13 +74,13 @@ public sealed partial class SeriesCardDisplay : UserControl
 
     private static readonly Animation _fadeInAnimation = new()
     {
-        Duration = TimeSpan.FromMilliseconds(650),
+        Duration = TimeSpan.FromMilliseconds(950),
         Easing = new QuadraticEaseOut(),
         FillMode = FillMode.Forward,
         Children =
         {
             new KeyFrame { Cue = new Cue(0.0), Setters = { new Setter(OpacityProperty, 0.0) } },
-            new KeyFrame { Cue = new Cue(0.3), Setters = { new Setter(OpacityProperty, 0.0) } },
+            new KeyFrame { Cue = new Cue(0.2), Setters = { new Setter(OpacityProperty, 0.0) } },
             new KeyFrame { Cue = new Cue(1.0), Setters = { new Setter(OpacityProperty, 1.0) } }
         }
     };

--- a/Src/Helpers/AppLog.cs
+++ b/Src/Helpers/AppLog.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MsLogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Tsundoku.Helpers;
+
+/// <summary>
+/// Static accessor for <see cref="ILoggerFactory"/> so that static classes that can't
+/// receive DI (e.g. parsers, static helpers, model schema migrations) can still emit
+/// source-generated log messages.
+/// </summary>
+public static class AppLog
+{
+    private static ILoggerFactory _factory = NullLoggerFactory.Instance;
+
+    /// <summary>Called once after the DI container is built.</summary>
+    public static void SetFactory(ILoggerFactory factory) => _factory = factory;
+
+    public static MsLogger CreateLogger<T>() => _factory.CreateLogger<T>();
+
+    public static MsLogger CreateLogger(string categoryName) => _factory.CreateLogger(categoryName);
+}

--- a/Src/Helpers/SeriesUrlParser.cs
+++ b/Src/Helpers/SeriesUrlParser.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Tsundoku.Helpers;
+
+public enum SeriesUrlSource
+{
+    AniList,
+    MangaDex
+}
+
+public sealed record SeriesUrlInfo(SeriesUrlSource Source, string Id);
+
+/// <summary>
+/// Detects supported manga/light-novel URLs and extracts the series identifier so the
+/// Add-Series flow can prefill the input with the source's native ID. Uses the same
+/// segment-walk pattern as <see cref="Tsundoku.Models.Series.GetLinkId"/>.
+/// </summary>
+public static class SeriesUrlParser
+{
+    public static bool TryParse(string? input, [NotNullWhen(true)] out SeriesUrlInfo? info)
+    {
+        info = null;
+        if (string.IsNullOrWhiteSpace(input)) return false;
+
+        if (!Uri.TryCreate(input.Trim(), UriKind.Absolute, out Uri? uri)) return false;
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) return false;
+
+        string host = uri.Host;
+        if (host.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
+        {
+            host = host[4..];
+        }
+
+        return host switch
+        {
+            "anilist.co" => TryExtract(uri, "manga", static s => uint.TryParse(s, out _), SeriesUrlSource.AniList, out info),
+            "mangadex.org" => TryExtract(uri, "title", Tsundoku.Clients.MangaDex.IsMangaDexId, SeriesUrlSource.MangaDex, out info),
+            _ => false
+        };
+    }
+
+    private static bool TryExtract(
+        Uri uri,
+        string marker,
+        Func<string, bool> idValidator,
+        SeriesUrlSource source,
+        [NotNullWhen(true)] out SeriesUrlInfo? info)
+    {
+        info = null;
+        string[] segments = uri.Segments;
+        for (int i = 0; i < segments.Length - 1; i++)
+        {
+            string seg = segments[i].TrimEnd('/');
+            if (seg.Equals(marker, StringComparison.OrdinalIgnoreCase))
+            {
+                string candidate = segments[i + 1].TrimEnd('/');
+                if (idValidator(candidate))
+                {
+                    info = new SeriesUrlInfo(source, candidate);
+                    return true;
+                }
+                return false;
+            }
+        }
+        return false;
+    }
+}

--- a/Src/Helpers/WindowHelper.cs
+++ b/Src/Helpers/WindowHelper.cs
@@ -22,6 +22,13 @@ public static class WindowHelper
 
         window.Closing += (s, e) =>
         {
+            if (App.IsShuttingDown)
+            {
+                window.IsOpen = false;
+                onClosing?.Invoke();
+                return;
+            }
+
             if (window.IsOpen)
             {
                 window.Hide();

--- a/Src/Models/SavedShelf.cs
+++ b/Src/Models/SavedShelf.cs
@@ -1,0 +1,15 @@
+using ReactiveUI;
+using ReactiveUI.SourceGenerators;
+
+namespace Tsundoku.Models;
+
+/// <summary>
+/// A user-named saved filter expression that appears as a one-click chip in the main window.
+/// </summary>
+public sealed partial class SavedShelf : ReactiveObject
+{
+    [Reactive] public partial string Name { get; set; } = string.Empty;
+    [Reactive] public partial string Query { get; set; } = string.Empty;
+    [Reactive] public partial string IconKey { get; set; } = "fa7-solid fa7-bookmark";
+    public Guid Id { get; set; } = Guid.NewGuid();
+}

--- a/Src/Models/User.cs
+++ b/Src/Models/User.cs
@@ -46,6 +46,7 @@ public sealed partial class User : ReactiveObject
     public List<TsundokuLanguage> AdditionalLanguages { get; set; } = [];
     public List<TsundokuTheme> SavedThemes { get; set; }
     public List<Series> UserCollection { get; set; }
+    public List<SavedShelf> SavedShelves { get; set; } = [];
 
     [JsonConverter(typeof(UserIconBitmapJsonConverter))]
     [Reactive] public partial Bitmap? UserIcon { get; set; }
@@ -432,6 +433,17 @@ public sealed partial class User : ReactiveObject
             }
             userData[nameof(DataVersion)] = 6.2;
             LOGGER.Info("Updated schema to v6.2: Removed 15 unused theme colors, added 8 new theme colors");
+        }
+
+        if (curVersion < 6.4) // 6.4 Adds SavedShelves (named filter expressions for the main window).
+        {
+            if (!userData.AsObject().ContainsKey(nameof(SavedShelves)))
+            {
+                userData.AsObject().Add(nameof(SavedShelves), new JsonArray());
+            }
+            userData[nameof(DataVersion)] = 6.4;
+            LOGGER.Info("Updated schema to v6.4: Added SavedShelves");
+            updatedVersion = true;
         }
 
         if (!isImport)

--- a/Src/Services/ApiHealthCheckService.cs
+++ b/Src/Services/ApiHealthCheckService.cs
@@ -2,7 +2,9 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using GraphQL;
 using GraphQL.Client.Http;
+using Microsoft.Extensions.Logging;
 using Tsundoku.Clients;
+using MsLogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Tsundoku.Services;
 
@@ -36,8 +38,7 @@ public interface IApiHealthCheckService : IDisposable
 /// </summary>
 public sealed class ApiHealthCheckService : IApiHealthCheckService
 {
-    private static readonly Logger LOGGER = LogManager.GetCurrentClassLogger();
-
+    private readonly MsLogger _logger;
     private readonly AniListGraphQLClient _aniListClient;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly BehaviorSubject<bool> _aniListStatus = new(true);
@@ -50,17 +51,18 @@ public sealed class ApiHealthCheckService : IApiHealthCheckService
     public IObservable<bool> IsMangaDexAvailable => _mangaDexStatus.DistinctUntilChanged();
     public bool IsAniListUp => _aniListStatus.Value;
 
-    public ApiHealthCheckService(AniListGraphQLClient aniListClient, IHttpClientFactory httpClientFactory)
+    public ApiHealthCheckService(AniListGraphQLClient aniListClient, IHttpClientFactory httpClientFactory, ILogger<ApiHealthCheckService> logger)
     {
         _aniListClient = aniListClient;
         _httpClientFactory = httpClientFactory;
+        _logger = logger;
     }
 
     public void Start()
     {
         // Run immediately then every 10 minutes
         _timer = new Timer(_ => _ = CheckAllSafeAsync(), null, TimeSpan.Zero, TimeSpan.FromMinutes(CheckIntervalMinutes));
-        LOGGER.Info("API health check service started (interval: {Interval} minutes)", CheckIntervalMinutes);
+        _logger.ServiceStarted(CheckIntervalMinutes);
     }
 
     public async Task<(bool AniList, bool MangaDex)> CheckNowAsync()
@@ -77,7 +79,7 @@ public sealed class ApiHealthCheckService : IApiHealthCheckService
         }
         catch (Exception ex)
         {
-            LOGGER.Error(ex, "Unhandled exception during API health check");
+            _logger.UnhandledCheckException(ex);
         }
     }
 
@@ -86,7 +88,7 @@ public sealed class ApiHealthCheckService : IApiHealthCheckService
         _timer?.Change(Timeout.Infinite, Timeout.Infinite);
         _timer?.Dispose();
         _timer = null;
-        LOGGER.Info("API health check service stopped");
+        _logger.ServiceStopped();
     }
 
     private async Task CheckAllAsync()
@@ -110,17 +112,17 @@ public sealed class ApiHealthCheckService : IApiHealthCheckService
             if (!isAvailable)
             {
                 string errorMsg = string.Join("; ", response.Errors!.Select(e => e.Message));
-                LOGGER.Warn("AniList API health check failed: {Error}", errorMsg);
+                _logger.AniListCheckFailedResponse(errorMsg);
             }
             else
             {
-                LOGGER.Debug("AniList API health check passed");
+                _logger.AniListCheckPassed();
             }
         }
         catch (Exception ex)
         {
             _aniListStatus.OnNext(false);
-            LOGGER.Warn(ex, "AniList API health check failed with exception");
+            _logger.AniListCheckFailedException(ex);
         }
     }
 
@@ -135,17 +137,17 @@ public sealed class ApiHealthCheckService : IApiHealthCheckService
 
             if (!isAvailable)
             {
-                LOGGER.Warn("MangaDex API health check failed: {StatusCode}", response.StatusCode);
+                _logger.MangaDexCheckFailedResponse(response.StatusCode);
             }
             else
             {
-                LOGGER.Debug("MangaDex API health check passed");
+                _logger.MangaDexCheckPassed();
             }
         }
         catch (Exception ex)
         {
             _mangaDexStatus.OnNext(false);
-            LOGGER.Warn(ex, "MangaDex API health check failed with exception");
+            _logger.MangaDexCheckFailedException(ex);
         }
     }
 

--- a/Src/Services/ApiHealthCheckServiceLogging.cs
+++ b/Src/Services/ApiHealthCheckServiceLogging.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Tsundoku.Services;
+
+internal static partial class ApiHealthCheckServiceLogging
+{
+    [LoggerMessage(Level = LogLevel.Information, Message = "API health check service started (interval: {IntervalMinutes} minutes)")]
+    public static partial void ServiceStarted(this ILogger logger, int intervalMinutes);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "API health check service stopped")]
+    public static partial void ServiceStopped(this ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Unhandled exception during API health check")]
+    public static partial void UnhandledCheckException(this ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AniList API health check failed: {Error}")]
+    public static partial void AniListCheckFailedResponse(this ILogger logger, string error);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "AniList API health check passed")]
+    public static partial void AniListCheckPassed(this ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AniList API health check failed with exception")]
+    public static partial void AniListCheckFailedException(this ILogger logger, Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "MangaDex API health check failed: {StatusCode}")]
+    public static partial void MangaDexCheckFailedResponse(this ILogger logger, HttpStatusCode statusCode);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "MangaDex API health check passed")]
+    public static partial void MangaDexCheckPassed(this ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "MangaDex API health check failed with exception")]
+    public static partial void MangaDexCheckFailedException(this ILogger logger, Exception ex);
+}

--- a/Src/Services/UserService.cs
+++ b/Src/Services/UserService.cs
@@ -34,6 +34,21 @@ public interface IUserService : IDisposable
     /// <summary>Gets an observable stream of change sets for the user's saved themes.</summary>
     IObservable<IChangeSet<TsundokuTheme, string>> SavedThemeChanges { get; }
 
+    /// <summary>Gets an observable stream of change sets for the user's saved shelves (named filters).</summary>
+    IObservable<IChangeSet<SavedShelf, Guid>> SavedShelfChanges { get; }
+
+    /// <summary>Gets the sorted, read-only collection of saved shelves.</summary>
+    ReadOnlyObservableCollection<SavedShelf> SavedShelves { get; }
+
+    /// <summary>Adds or updates a saved shelf.</summary>
+    void AddShelf(SavedShelf shelf);
+
+    /// <summary>Removes the shelf with the given id.</summary>
+    void RemoveShelf(Guid shelfId);
+
+    /// <summary>Renames an existing shelf.</summary>
+    void RenameShelf(Guid shelfId, string newName);
+
     /// <summary>Applies an update action to the current user and notifies subscribers.</summary>
     /// <param name="updateAction">The action to apply to the current user.</param>
     void UpdateUser(Action<User> updateAction);
@@ -203,8 +218,13 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
     private readonly SourceCache<TsundokuTheme, string> _savedThemesSourceCache = new(t => t.ThemeName);
     public IObservable<IChangeSet<TsundokuTheme, string>> SavedThemeChanges => _savedThemesSourceCache.Connect();
 
+    private readonly SourceCache<SavedShelf, Guid> _savedShelvesSourceCache = new(s => s.Id);
+    public IObservable<IChangeSet<SavedShelf, Guid>> SavedShelfChanges => _savedShelvesSourceCache.Connect();
+
     // private readonly ReadOnlyObservableCollection<Series> _userCollection;
     private readonly ReadOnlyObservableCollection<TsundokuTheme> _savedThemes;
+    private readonly ReadOnlyObservableCollection<SavedShelf> _savedShelves;
+    public ReadOnlyObservableCollection<SavedShelf> SavedShelves => _savedShelves;
 
     [Reactive] public partial string SeriesFilterText { get; set; } = string.Empty;
     [Reactive] public partial TsundokuFilter SelectedFilter { get; set; } = TsundokuFilter.None;
@@ -256,6 +276,14 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
 
         SavedThemeChanges
             .SortAndBind(out _savedThemes, new TsundokuThemeComparer(TsundokuLanguage.English))
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe()
+            .DisposeWith(_disposables);
+
+        SavedShelfChanges
+            .SortAndBind(
+                out _savedShelves,
+                Comparer<SavedShelf>.Create((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase)))
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe()
             .DisposeWith(_disposables);
@@ -515,6 +543,11 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
             _userCollectionSourceCache.Clear();
             _userCollectionSourceCache.AddOrUpdate(user!.UserCollection);
             SyncCoverFilesAndCleanupOrphans(_userCollectionSourceCache);
+        }
+        if (user!.SavedShelves is not null)
+        {
+            _savedShelvesSourceCache.Clear();
+            _savedShelvesSourceCache.AddOrUpdate(user!.SavedShelves);
         }
     }
 
@@ -1102,6 +1135,87 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
     }
     
     public void ClearUserCollection() => _userCollectionSourceCache.Clear();
+
+    public void AddShelf(SavedShelf shelf)
+    {
+        ArgumentNullException.ThrowIfNull(shelf);
+        if (string.IsNullOrWhiteSpace(shelf.Name))
+        {
+            throw new ArgumentException("Shelf name cannot be null, empty, or whitespace.", nameof(shelf));
+        }
+        if (shelf.Name.Length > 60)
+        {
+            throw new ArgumentException("Shelf name must be 60 characters or fewer.", nameof(shelf));
+        }
+
+        _savedShelvesSourceCache.AddOrUpdate(shelf);
+
+        UpdateUser(user =>
+        {
+            int existing = user.SavedShelves.FindIndex(s => s.Id == shelf.Id);
+            if (existing >= 0)
+            {
+                user.SavedShelves[existing] = shelf;
+            }
+            else
+            {
+                user.SavedShelves.Add(shelf);
+            }
+        });
+
+        LOGGER.Info("Added or updated shelf '{Name}' ({Id})", shelf.Name, shelf.Id);
+    }
+
+    public void RemoveShelf(Guid shelfId)
+    {
+        if (!_savedShelvesSourceCache.Lookup(shelfId).HasValue)
+        {
+            LOGGER.Warn("Shelf {Id} not found in cache; nothing to remove", shelfId);
+            return;
+        }
+
+        _savedShelvesSourceCache.Remove(shelfId);
+
+        UpdateUser(user =>
+        {
+            user.SavedShelves.RemoveAll(s => s.Id == shelfId);
+        });
+
+        LOGGER.Info("Removed shelf {Id}", shelfId);
+    }
+
+    public void RenameShelf(Guid shelfId, string newName)
+    {
+        if (string.IsNullOrWhiteSpace(newName))
+        {
+            throw new ArgumentException("Shelf name cannot be null, empty, or whitespace.", nameof(newName));
+        }
+        if (newName.Length > 60)
+        {
+            throw new ArgumentException("Shelf name must be 60 characters or fewer.", nameof(newName));
+        }
+
+        Optional<SavedShelf> existing = _savedShelvesSourceCache.Lookup(shelfId);
+        if (!existing.HasValue)
+        {
+            LOGGER.Warn("Shelf {Id} not found in cache; cannot rename", shelfId);
+            return;
+        }
+
+        existing.Value.Name = newName;
+        _savedShelvesSourceCache.AddOrUpdate(existing.Value);
+
+        UpdateUser(user =>
+        {
+            SavedShelf? userCopy = user.SavedShelves.FirstOrDefault(s => s.Id == shelfId);
+            if (userCopy is not null)
+            {
+                userCopy.Name = newName;
+            }
+        });
+
+        LOGGER.Info("Renamed shelf {Id} → '{Name}'", shelfId, newName);
+    }
 
     public void ExportTheme(string fileName)
     {

--- a/Src/Tsundoku.csproj
+++ b/Src/Tsundoku.csproj
@@ -95,8 +95,10 @@
 		<PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" />
 		<PackageReference Include="MangaAndLightNovelWebScrape" />
 		<PackageReference Include="Microsoft.Extensions.Http" />
+		<PackageReference Include="Microsoft.Extensions.Logging" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
 		<PackageReference Include="NLog" />
+		<PackageReference Include="NLog.Extensions.Logging" />
 		<PackageReference Include="D2Phap.FileWatcherEx" />
 		<PackageReference Include="Optris.Icons.Avalonia.FontAwesome7" />
 		<PackageReference Include="ReactiveUI.Avalonia" />

--- a/Src/ViewModels/AddNewSeriesViewModel.cs
+++ b/Src/ViewModels/AddNewSeriesViewModel.cs
@@ -38,6 +38,7 @@ public sealed partial class AddNewSeriesViewModel : ViewModelBase, IDisposable
     [Reactive] public partial bool IsAddSeriesButtonEnabled { get; set; } = false;
     [Reactive] public partial string SeriesValueMaskedText { get; set; }
     [Reactive] public partial AvaloniaList<TsundokuLanguage> SelectedAdditionalLanguages { get; set; } = [];
+    [Reactive] public partial SeriesUrlSource? DetectedUrlSource { get; set; }
 
     private readonly SourceList<AniListPickerSuggestion> _suggestionsSource = new();
     public ReadOnlyObservableCollection<AniListPickerSuggestion> Suggestions { get; private set; }
@@ -105,6 +106,27 @@ public sealed partial class AddNewSeriesViewModel : ViewModelBase, IDisposable
             .Subscribe(x => IsSuggestionsOpen = x)
             .DisposeWith(_disposables);
 
+
+        this.WhenAnyValue(x => x.TitleText)
+            .Select(x => x is null ? string.Empty : x.Trim())
+            .DistinctUntilChanged()
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(text =>
+            {
+                if (SeriesUrlParser.TryParse(text, out SeriesUrlInfo? info))
+                {
+                    DetectedUrlSource = info.Source;
+                    if (!string.Equals(text, info.Id, StringComparison.Ordinal))
+                    {
+                        TitleText = info.Id;
+                    }
+                }
+                else if (string.IsNullOrEmpty(text))
+                {
+                    DetectedUrlSource = null;
+                }
+            })
+            .DisposeWith(_disposables);
 
         this.WhenAnyValue(x => x.TitleText)
             .Select(x => x is null ? string.Empty : x.Trim())

--- a/Src/ViewModels/EditSeriesInfoViewModel.cs
+++ b/Src/ViewModels/EditSeriesInfoViewModel.cs
@@ -7,6 +7,7 @@ using ReactiveUI;
 using ReactiveUI.SourceGenerators;
 using Tsundoku.Helpers;
 using Tsundoku.Models;
+using Tsundoku.Services;
 using static Tsundoku.Models.Enums.SeriesDemographicModel;
 using static Tsundoku.Models.Enums.SeriesGenreModel;
 
@@ -18,18 +19,23 @@ namespace Tsundoku.ViewModels;
 public sealed partial class EditSeriesInfoViewModel : ViewModelBase, IDisposable
 {
     private static readonly Logger LOGGER = LogManager.GetCurrentClassLogger();
-    public Series Series { get; }
+    private readonly ISharedSeriesCollectionProvider? _sharedSeriesProvider;
+    [Reactive] public partial Series Series { get; set; }
     [Reactive] public partial int DemographicIndex { get; set; }
     [Reactive] public partial string CoverImageUrl { get; set; }
     [Reactive] public partial string GenresToolTipText { get; set; }
     [Reactive] public partial string SeriesValueText { get; set; }
     [Reactive] public partial string SeriesValueMaskedText { get; set; }
     [Reactive] public partial string VolumesReadText { get; set; }
+    [Reactive] public partial bool HasPrevious { get; set; }
+    [Reactive] public partial bool HasNext { get; set; }
     public AvaloniaList<string> SelectedGenres { get; set; } = [];
 
-    public EditSeriesInfoViewModel(Series series, IUserService userService) : base(userService)
+    public EditSeriesInfoViewModel(Series series, IUserService userService, ISharedSeriesCollectionProvider? sharedSeriesProvider = null) : base(userService)
     {
         Series = series;
+        _sharedSeriesProvider = sharedSeriesProvider;
+        RecomputeNavigationFlags();
         this.WhenAnyValue(x => x.Series.Demographic)
             .DistinctUntilChanged()
             .ObserveOn(RxSchedulers.TaskpoolScheduler)
@@ -122,6 +128,53 @@ public sealed partial class EditSeriesInfoViewModel : ViewModelBase, IDisposable
             }
         }
         return newGenres;
+    }
+
+    /// <summary>Swaps to the previous series in the active filtered/sorted collection, if any.</summary>
+    public bool NavigatePrevious()
+    {
+        if (_sharedSeriesProvider is null) return false;
+        IReadOnlyList<Series> list = _sharedSeriesProvider.DynamicUserCollection;
+        int index = IndexOfCurrent(list);
+        if (index <= 0) return false;
+        Series = list[index - 1];
+        RecomputeNavigationFlags();
+        return true;
+    }
+
+    /// <summary>Swaps to the next series in the active filtered/sorted collection, if any.</summary>
+    public bool NavigateNext()
+    {
+        if (_sharedSeriesProvider is null) return false;
+        IReadOnlyList<Series> list = _sharedSeriesProvider.DynamicUserCollection;
+        int index = IndexOfCurrent(list);
+        if (index < 0 || index >= list.Count - 1) return false;
+        Series = list[index + 1];
+        RecomputeNavigationFlags();
+        return true;
+    }
+
+    private int IndexOfCurrent(IReadOnlyList<Series> list)
+    {
+        for (int i = 0; i < list.Count; i++)
+        {
+            if (ReferenceEquals(list[i], Series)) return i;
+        }
+        return -1;
+    }
+
+    private void RecomputeNavigationFlags()
+    {
+        if (_sharedSeriesProvider is null)
+        {
+            HasPrevious = false;
+            HasNext = false;
+            return;
+        }
+        IReadOnlyList<Series> list = _sharedSeriesProvider.DynamicUserCollection;
+        int index = IndexOfCurrent(list);
+        HasPrevious = index > 0;
+        HasNext = index >= 0 && index < list.Count - 1;
     }
 
     public void Dispose()

--- a/Src/ViewModels/MainWindowViewModel.cs
+++ b/Src/ViewModels/MainWindowViewModel.cs
@@ -126,6 +126,15 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
                 string query = shelf?.Query ?? string.Empty;
                 AdvancedSearchQuery = query;
                 _sharedSeriesProvider.AdvancedSearchQuery = query;
+
+                if (shelf is not null)
+                {
+                    LOGGER.Info("Shelf \"{ShelfName}\" applied: {Query}", shelf.Name, shelf.Query);
+                }
+                else
+                {
+                    LOGGER.Info("Shelf cleared");
+                }
             })
             .DisposeWith(_disposables);
     }
@@ -177,7 +186,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
 
     public async Task CreateEditSeriesDialog(Series series)
     {
-        await EditSeriesInfoDialog.Handle(new EditSeriesInfoViewModel(series, _userService));
+        await EditSeriesInfoDialog.Handle(new EditSeriesInfoViewModel(series, _userService, _sharedSeriesProvider));
     }
 
     public void UpdateUserIcon(string filePath)

--- a/Src/ViewModels/MainWindowViewModel.cs
+++ b/Src/ViewModels/MainWindowViewModel.cs
@@ -42,7 +42,9 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
     public ReadOnlyObservableCollection<Series> UserCollection { get; }
     public ReadOnlyObservableCollection<string> AvailablePublishers => _sharedSeriesProvider.AvailablePublishers;
     public ReadOnlyObservableCollection<TsundokuTheme> SavedThemes => _userService.SavedThemes;
+    public ReadOnlyObservableCollection<SavedShelf> Shelves => _userService.SavedShelves;
     public FilterBuilderViewModel FilterBuilder { get; } = new();
+    [Reactive] public partial SavedShelf? SelectedShelf { get; set; }
 
     public Interaction<EditSeriesInfoViewModel, MainWindowViewModel?> EditSeriesInfoDialog { get; } = new Interaction<EditSeriesInfoViewModel, MainWindowViewModel?>();
 
@@ -115,6 +117,46 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IDisposable
                 }
             })
             .DisposeWith(_disposables);
+
+        this.WhenAnyValue(x => x.SelectedShelf)
+            .DistinctUntilChanged()
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(shelf =>
+            {
+                string query = shelf?.Query ?? string.Empty;
+                AdvancedSearchQuery = query;
+                _sharedSeriesProvider.AdvancedSearchQuery = query;
+            })
+            .DisposeWith(_disposables);
+    }
+
+    public void SaveCurrentFilterAsShelf(string name)
+    {
+        string query = FilterBuilder.SynthesizedQuery;
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            LOGGER.Warn("Cannot save an empty filter as a shelf");
+            return;
+        }
+
+        SavedShelf shelf = new() { Name = name.Trim(), Query = query };
+        _userService.AddShelf(shelf);
+    }
+
+    public void DeleteShelf(SavedShelf shelf)
+    {
+        if (shelf is null) return;
+        if (ReferenceEquals(SelectedShelf, shelf))
+        {
+            SelectedShelf = null;
+        }
+        _userService.RemoveShelf(shelf.Id);
+    }
+
+    public void RenameShelf(SavedShelf shelf, string newName)
+    {
+        if (shelf is null || string.IsNullOrWhiteSpace(newName)) return;
+        _userService.RenameShelf(shelf.Id, newName.Trim());
     }
 
     public void SaveUserData()

--- a/Src/ViewModels/PriceAnalysisViewModel.cs
+++ b/Src/ViewModels/PriceAnalysisViewModel.cs
@@ -3,8 +3,8 @@ using System.Collections.Specialized;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using Avalonia.Collections;
-using Avalonia.Controls;
 using MangaAndLightNovelWebScrape;
+using MangaAndLightNovelWebScrape.Websites;
 using ReactiveUI;
 using ReactiveUI.SourceGenerators;
 
@@ -21,9 +21,30 @@ public sealed partial class PriceAnalysisViewModel : ViewModelBase, IDisposable
     [Reactive] public partial bool WebsitesSelected { get; set; } = false;
     [Reactive] public partial string WebsitesToolTipText { get; set; }
     [Reactive] public partial int CurRegionIndex { get; set; }
-    public AvaloniaList<ListBoxItem> SelectedWebsites { get; } = [];
+    public AvaloniaList<string> AvailableWebsites { get; } = [];
+    public AvaloniaList<string> SelectedWebsites { get; } = [];
     private readonly StringBuilder _curWebsites = new();
     private static readonly Region[] CachedRegionValues = Enum.GetValues<Region>();
+
+    private static readonly FrozenDictionary<Website, string> WebsiteTitles =
+        new Dictionary<Website, string>
+        {
+            [Website.AllStarComics] = AllStarComics.TITLE,
+            [Website.AmazonUSA] = AmazonUSA.TITLE,
+            [Website.BooksAMillion] = BooksAMillion.TITLE,
+            [Website.Crunchyroll] = Crunchyroll.TITLE,
+            [Website.ForbiddenPlanet] = ForbiddenPlanet.TITLE,
+            [Website.InStockTrades] = InStockTrades.TITLE,
+            [Website.KingsComics] = KingsComics.TITLE,
+            [Website.KinokuniyaUSA] = KinokuniyaUSA.TITLE,
+            [Website.MangaMart] = MangaMart.TITLE,
+            [Website.MangaMate] = MangaMate.TITLE,
+            [Website.MerryManga] = MerryManga.TITLE,
+            [Website.OKComics] = OKComics.TITLE,
+            [Website.RobertsAnimeCornerStore] = RobertsAnimeCornerStore.TITLE,
+            [Website.SciFier] = SciFier.TITLE,
+            [Website.TravellingMan] = TravellingMan.TITLE,
+        }.ToFrozenDictionary();
 
     public static readonly FrozenSet<string> ANALYSIS_COUNTRY_OPTIONS = new[]
     {
@@ -48,12 +69,29 @@ public sealed partial class PriceAnalysisViewModel : ViewModelBase, IDisposable
 
     public PriceAnalysisViewModel(IUserService userService) : base(userService)
     {
-
         SelectedWebsites.CollectionChanged += WebsiteCollectionChanged;
+
         this.WhenAnyValue(x => x.CurrentUser.Region)
             .DistinctUntilChanged()
-            .Subscribe(x => CurRegionIndex = Array.IndexOf(CachedRegionValues, x))
+            .Subscribe(region =>
+            {
+                CurRegionIndex = Array.IndexOf(CachedRegionValues, region);
+                RebuildAvailableWebsites(region);
+            })
             .DisposeWith(_disposables);
+    }
+
+    private void RebuildAvailableWebsites(Region region)
+    {
+        SelectedWebsites.Clear();
+        AvailableWebsites.Clear();
+        foreach (Website site in MangaAndLightNovelWebScrape.Helpers.GetRegionWebsiteList(region))
+        {
+            if (WebsiteTitles.TryGetValue(site, out string? title))
+            {
+                AvailableWebsites.Add(title);
+            }
+        }
     }
 
     /// <summary>
@@ -75,9 +113,9 @@ public sealed partial class PriceAnalysisViewModel : ViewModelBase, IDisposable
 
         for (int x = 0; x < SelectedWebsites.Count - 1; x++)
         {
-            _curWebsites.AppendLine(SelectedWebsites[x].Content.ToString());
+            _curWebsites.AppendLine(SelectedWebsites[x]);
         }
-        _curWebsites.Append(SelectedWebsites[^1].Content.ToString());
+        _curWebsites.Append(SelectedWebsites[^1]);
         WebsitesToolTipText = _curWebsites.ToString();
         _curWebsites.Clear();
     }

--- a/Src/ViewModels/ViewModelBase.cs
+++ b/Src/ViewModels/ViewModelBase.cs
@@ -29,7 +29,7 @@ public partial class ViewModelBase : ReactiveObject
         .Split('+')[0];
 
     /// <summary>The current user data schema version for migration logic.</summary>
-    public const double SCHEMA_VERSION = 6.3;
+    public const double SCHEMA_VERSION = 6.4;
 
     /// <summary>The file name used for persisting user data.</summary>
     public const string USER_DATA_FILEPATH = @"UserData.json";

--- a/Src/Views/AddNewSeriesWindow.axaml
+++ b/Src/Views/AddNewSeriesWindow.axaml
@@ -33,12 +33,37 @@
 				<StackPanel Grid.Column="0" Spacing="12" Name="FormFields" Width="520">
 					<!-- Title -->
 					<StackPanel Spacing="4">
-						<TextBlock Text="TITLE OR ID" Classes="section-title" ToolTip.Tip="{Binding #SeriesInputTextBox.Text}"/>
+						<StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+							<Border x:Name="UrlSourcePill"
+									Padding="8,3"
+									CornerRadius="10"
+									Background="{DynamicResource TsundokuStatusAndBookTypeBGColor}"
+									BorderBrush="{DynamicResource TsundokuStatusAndBookTypeBorderColor}"
+									BorderThickness="1.5"
+									VerticalAlignment="Center"
+									IsVisible="{CompiledBinding DetectedUrlSource, Converter={x:Static ObjectConverters.IsNotNull}}">
+								<StackPanel Orientation="Horizontal" Spacing="6">
+									<i:Icon Value="fa7-solid fa7-link" FontSize="10"
+											Foreground="{DynamicResource TsundokuStatusAndBookTypeTextColor}"
+											VerticalAlignment="Center"/>
+									<TextBlock FontSize="10" FontWeight="Bold"
+											   Foreground="{DynamicResource TsundokuStatusAndBookTypeTextColor}"
+											   VerticalAlignment="Center">
+										<Run Text="Detected: "/>
+										<Run Text="{CompiledBinding DetectedUrlSource}"/>
+									</TextBlock>
+								</StackPanel>
+							</Border>
+							<TextBlock Text="TITLE, ID OR LINK" Classes="section-title" VerticalAlignment="Center" ToolTip.Tip="{Binding #SeriesInputTextBox.Text}"/>
+						</StackPanel>
 						<TextBox x:Name="SeriesInputTextBox"
-							FontSize="13" FontWeight="Bold" Height="60"
+							FontSize="13" FontWeight="Bold"
+							Height="90" MinHeight="90" MaxHeight="90"
 							Text="{CompiledBinding TitleText}" Classes="Menu"
 							BorderThickness="2" TextWrapping="Wrap"
-							PlaceholderText="Title or AniList/MangaDex ID..."/>
+							ScrollViewer.VerticalScrollBarVisibility="Auto"
+							ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+							PlaceholderText="Title, AniList/MangaDex ID, or paste URL..."/>
 					</StackPanel>
 
 					<Popup

--- a/Src/Views/EditSeriesInfoWindow.axaml
+++ b/Src/Views/EditSeriesInfoWindow.axaml
@@ -16,25 +16,50 @@
         <Grid RowDefinitions="Auto,*">
             <!-- Header -->
             <Border Grid.Row="0" BorderThickness="0,0,0,2" BorderBrush="{DynamicResource TsundokuDividerColor}" Padding="16,12">
-                <Grid ColumnDefinitions="*,Auto">
-                    <StackPanel Orientation="Horizontal" Spacing="8" ClipToBounds="True">
-                        <i:Icon Value="fa7-solid fa7-pen-to-square" FontSize="16" Foreground="{DynamicResource TsundokuDividerColor}"/>
-                        <TextBlock FontSize="18" FontWeight="ExtraBold" Foreground="{DynamicResource TsundokuUsernameColor}" VerticalAlignment="Center"
-                                   TextTrimming="CharacterEllipsis">
-                            <TextBlock.Text>
-                                <MultiBinding StringFormat="Edit Series — {0}">
-                                    <Binding Path="Title" RelativeSource="{RelativeSource AncestorType=Window}"/>
-                                </MultiBinding>
-                            </TextBlock.Text>
-                        </TextBlock>
+                <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto">
+                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <i:Icon Value="fa7-solid fa7-pen-to-square" FontSize="16" Foreground="{DynamicResource TsundokuDividerColor}" VerticalAlignment="Center"/>
+                        <TextBlock Text="Edit Series"
+                                   FontSize="18"
+                                   FontWeight="ExtraBold"
+                                   Foreground="{DynamicResource TsundokuUsernameColor}"
+                                   VerticalAlignment="Center"/>
                     </StackPanel>
-                    <Button Grid.Column="1"
+                    <Button Grid.Row="0" Grid.Column="1"
                             x:Name="DeleteSeriesButton"
                             i:Attached.Icon="fa7-solid fa7-trash-can"
                             FontSize="14" Width="34" Height="34"
                             Theme="{StaticResource MenuButton}"
                             ToolTip.Tip="Delete Series"
+                            VerticalAlignment="Top"
                             Click="RemoveSeries"/>
+                    <ItemsControl Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                  ItemsSource="{CompiledBinding Series.Titles}"
+                                  Margin="26,6,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid ColumnDefinitions="Auto,*" Margin="0,1">
+                                    <TextBlock Grid.Column="0"
+                                               Text="{Binding Key}"
+                                               FontSize="10"
+                                               FontWeight="Bold"
+                                               LetterSpacing="0.5"
+                                               Opacity="0.55"
+                                               Foreground="{DynamicResource TsundokuMenuTextColor}"
+                                               VerticalAlignment="Top"
+                                               Margin="0,2,8,0"/>
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding Value}"
+                                               FontSize="13"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource TsundokuUsernameColor}"
+                                               TextWrapping="Wrap"
+                                               VerticalAlignment="Top"
+                                               MaxWidth="700"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </Grid>
             </Border>
 
@@ -46,7 +71,7 @@
                         <TextBlock Text="SERIES NOTES" Classes="section-title"/>
                         <TextBox x:Name="SeriesNotesTextBox"
                                  Height="160"
-                                 Width="460"
+                                 Width="560"
                                  Text="{CompiledBinding Series.SeriesNotes, Mode=TwoWay}"
                                  AcceptsReturn="True"
                                  TextWrapping="Wrap"
@@ -59,7 +84,7 @@
                     </StackPanel>
 
                     <!-- Current Vols / Max Vols / Volumes Read / Rating -->
-                    <Grid ColumnDefinitions="*,6,*,6,*,6,*" RowDefinitions="Auto,Auto" MinWidth="460">
+                    <Grid ColumnDefinitions="*,6,*,6,*,6,*" RowDefinitions="Auto,Auto" MinWidth="560">
                         <TextBlock Grid.Row="0" Grid.Column="0" Text="CURRENT VOLS" Classes="section-title" Margin="0,0,0,4" HorizontalAlignment="Center"/>
                         <MaskedTextBox x:Name="CurVolumeMaskedTextBox"
                                        Grid.Row="1" Grid.Column="0"
@@ -108,7 +133,7 @@
                     <StackPanel Spacing="4">
                         <TextBlock Text="COVER IMAGE URL" Classes="section-title"
                                    ToolTip.Tip="{CompiledBinding CoverImageUrl}"/>
-                        <Grid ColumnDefinitions="*,6,Auto,6,Auto" Width="460">
+                        <Grid ColumnDefinitions="*,6,Auto,6,Auto" Width="560">
                             <TextBox x:Name="CoverImageUrlTextBox"
                                      Grid.Column="0"
                                      FontSize="13" Height="34"
@@ -135,7 +160,7 @@
                     </StackPanel>
 
                     <!-- Publisher / Value / Demographic -->
-                    <Grid ColumnDefinitions="*,6,*,6,*" RowDefinitions="Auto,Auto" MinWidth="460">
+                    <Grid ColumnDefinitions="*,6,*,6,*" RowDefinitions="Auto,Auto" MinWidth="560">
                         <TextBlock Grid.Row="0" Grid.Column="0" Text="PUBLISHER" Classes="section-title" Margin="0,0,0,4" HorizontalAlignment="Center"
                                    ToolTip.Tip="{CompiledBinding Series.Publisher}"/>
                         <TextBox x:Name="PublisherTextBox"

--- a/Src/Views/EditSeriesInfoWindow.axaml
+++ b/Src/Views/EditSeriesInfoWindow.axaml
@@ -25,14 +25,59 @@
                                    Foreground="{DynamicResource TsundokuUsernameColor}"
                                    VerticalAlignment="Center"/>
                     </StackPanel>
-                    <Button Grid.Row="0" Grid.Column="1"
-                            x:Name="DeleteSeriesButton"
-                            i:Attached.Icon="fa7-solid fa7-trash-can"
-                            FontSize="14" Width="34" Height="34"
-                            Theme="{StaticResource MenuButton}"
-                            ToolTip.Tip="Delete Series"
-                            VerticalAlignment="Top"
-                            Click="RemoveSeries"/>
+                    <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Top">
+                        <Button x:Name="PreviousSeriesButton"
+                                i:Attached.Icon="fa7-solid fa7-chevron-left"
+                                FontSize="14" Width="34" Height="34"
+                                Theme="{StaticResource MenuButton}"
+                                ToolTip.Tip="Previous Series"
+                                IsEnabled="{CompiledBinding HasPrevious}"
+                                Click="NavigatePreviousSeries"/>
+                        <Button x:Name="NextSeriesButton"
+                                i:Attached.Icon="fa7-solid fa7-chevron-right"
+                                FontSize="14" Width="34" Height="34"
+                                Theme="{StaticResource MenuButton}"
+                                ToolTip.Tip="Next Series"
+                                IsEnabled="{CompiledBinding HasNext}"
+                                Click="NavigateNextSeries"/>
+                        <Border Width="1" Margin="0,4" Background="{DynamicResource TsundokuDividerColor}" Opacity="0.5"/>
+                        <Button x:Name="OpenSeriesLinkButton"
+                                i:Attached.Icon="fa7-solid fa7-arrow-up-right-from-square"
+                                FontSize="14" Width="34" Height="34"
+                                Theme="{StaticResource MenuButton}"
+                                ToolTip.Tip="Open Series Link"
+                                Click="OpenSeriesLinkAsync"/>
+                        <ToggleButton x:Name="FavoriteButton"
+                                      IsChecked="{CompiledBinding Series.IsFavorite, Mode=TwoWay}"
+                                      Theme="{StaticResource MenuToggleButton}"
+                                      Height="34" Width="34" FontSize="14"
+                                      ToolTip.Tip="Favorite"
+                                      i:Attached.Icon="fa7-solid fa7-heart"/>
+                        <Button x:Name="ChangeSeriesVolumeCountButton"
+                                i:Attached.Icon="fa7-solid fa7-arrows-rotate"
+                                FontSize="14" Width="34" Height="34"
+                                Theme="{StaticResource MenuButton}"
+                                ToolTip.Tip="Refresh series data from AniList"
+                                Click="RefreshSeriesAsync"/>
+                        <Button x:Name="SaveStatsButton"
+                                i:Attached.Icon="fa7-solid fa7-floppy-disk"
+                                FontSize="14" Width="34" Height="34"
+                                Theme="{StaticResource MenuButton}"
+                                ToolTip.Tip="Save Stats"
+                                Click="SaveStats"/>
+                        <Button x:Name="MarkCompleteButton"
+                                i:Attached.Icon="fa7-solid fa7-check-double"
+                                FontSize="14" Width="34" Height="34"
+                                Theme="{StaticResource MenuButton}"
+                                ToolTip.Tip="Mark Complete (set current = max)"
+                                Click="MarkSeriesComplete"/>
+                        <Button x:Name="DeleteSeriesButton"
+                                i:Attached.Icon="fa7-solid fa7-trash-can"
+                                FontSize="14" Width="34" Height="34"
+                                Theme="{StaticResource MenuButton}"
+                                ToolTip.Tip="Delete Series"
+                                Click="RemoveSeries"/>
+                    </StackPanel>
                     <ItemsControl Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
                                   ItemsSource="{CompiledBinding Series.Titles}"
                                   Margin="26,6,0,0">
@@ -70,7 +115,7 @@
                     <StackPanel Spacing="4">
                         <TextBlock Text="SERIES NOTES" Classes="section-title"/>
                         <TextBox x:Name="SeriesNotesTextBox"
-                                 Height="160"
+                                 Height="220"
                                  Width="560"
                                  Text="{CompiledBinding Series.SeriesNotes, Mode=TwoWay}"
                                  AcceptsReturn="True"
@@ -203,35 +248,6 @@
                         </ComboBox>
                     </Grid>
 
-                    <!-- Action Buttons -->
-                    <Border Classes="divider"/>
-                    <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Center">
-                        <Button x:Name="ChangeSeriesVolumeCountButton"
-                                Theme="{StaticResource MenuButton}"
-                                Height="34" Padding="14,0" FontSize="13"
-                                ToolTip.Tip="Refresh series data from AniList"
-                                Click="RefreshSeriesAsync">
-                            <StackPanel Orientation="Horizontal" Spacing="6">
-                                <i:Icon Value="fa7-solid fa7-arrows-rotate" FontSize="13"/>
-                                <TextBlock Text="Refresh" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </Button>
-                        <Button Theme="{StaticResource MenuButton}"
-                                Height="34" Padding="14,0" FontSize="13"
-                                ToolTip.Tip="Save Stats"
-                                Click="SaveStats">
-                            <StackPanel Orientation="Horizontal" Spacing="6">
-                                <i:Icon Value="fa7-solid fa7-floppy-disk" FontSize="13"/>
-                                <TextBlock Text="Save" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </Button>
-                        <ToggleButton x:Name="FavoriteButton"
-                                      IsChecked="{CompiledBinding Series.IsFavorite, Mode=TwoWay}"
-                                      Theme="{StaticResource MenuToggleButton}"
-                                      Height="34" Width="34" FontSize="14"
-                                      ToolTip.Tip="Favorite"
-                                      i:Attached.Icon="fa7-solid fa7-heart"/>
-                    </StackPanel>
                 </StackPanel>
 
                 <!-- RIGHT COLUMN: Genres -->

--- a/Src/Views/EditSeriesInfoWindow.axaml.cs
+++ b/Src/Views/EditSeriesInfoWindow.axaml.cs
@@ -6,6 +6,7 @@ using Optris.Icons.Avalonia;
 using ReactiveUI.Avalonia;
 using System.Reactive.Linq;
 using Tsundoku.Helpers;
+using Tsundoku.Models;
 using Tsundoku.Services;
 using Tsundoku.ViewModels;
 using static Tsundoku.Models.Enums.SeriesDemographicModel;
@@ -33,18 +34,7 @@ public sealed partial class EditSeriesInfoWindow : ReactiveWindow<EditSeriesInfo
 
         Opened += (s, e) =>
         {
-            string curTitle = ViewModel.Series.Titles.TryGetValue(ViewModel.CurrentUser.Language, out string? title)
-                ? title
-                : ViewModel.Series.Titles[TsundokuLanguage.Romaji];
-
-            DiscordRP.SetPresence(
-                state: $"Editing {curTitle} {ViewModel.Series.Format}",
-                refreshTimestamp: true,
-                additionalButton: new DiscordRPC.Button { Label = "AniList", Url = ViewModel.Series.Link.ToString() });
-                
-            this.Title = $"{curTitle}";
-
-            UpdateSelectedGenres();
+            ApplyCurrentSeries();
             _IsInitialized = true;
 
             // Disable refresh if AniList is down
@@ -289,6 +279,67 @@ public sealed partial class EditSeriesInfoWindow : ReactiveWindow<EditSeriesInfo
             _mainWindowViewModel.DeleteSeries(ViewModel.Series);
             this.Close();
         }
+    }
+
+    private async void OpenSeriesLinkAsync(object sender, RoutedEventArgs args)
+    {
+        if (ViewModel?.Series?.Link is null) return;
+        await ViewModelBase.OpenSiteLink(ViewModel.Series.Link.ToString());
+    }
+
+    private void NavigatePreviousSeries(object sender, RoutedEventArgs args)
+    {
+        if (ViewModel?.NavigatePrevious() == true)
+        {
+            ApplyCurrentSeries();
+        }
+    }
+
+    private void NavigateNextSeries(object sender, RoutedEventArgs args)
+    {
+        if (ViewModel?.NavigateNext() == true)
+        {
+            ApplyCurrentSeries();
+        }
+    }
+
+    private void ApplyCurrentSeries()
+    {
+        if (ViewModel?.Series is null) return;
+
+        string curTitle = ViewModel.Series.Titles.TryGetValue(ViewModel.CurrentUser.Language, out string? title)
+            ? title
+            : ViewModel.Series.Titles[TsundokuLanguage.Romaji];
+
+        DiscordRP.SetPresence(
+            state: $"Editing {curTitle} {ViewModel.Series.Format}",
+            refreshTimestamp: true,
+            additionalButton: new DiscordRPC.Button { Label = "AniList", Url = ViewModel.Series.Link.ToString() });
+
+        this.Title = curTitle;
+        UpdateSelectedGenres();
+    }
+
+    private async void MarkSeriesComplete(object sender, RoutedEventArgs args)
+    {
+        if (ViewModel?.Series is null) return;
+
+        Series series = ViewModel.Series;
+        if (series.MaxVolumeCount == 0)
+        {
+            await _popupDialogService.ShowAsync(
+                "Max Volumes Unknown",
+                "fa7-solid fa7-circle-exclamation",
+                "Set the maximum volume count before marking this series complete.",
+                this);
+            return;
+        }
+
+        if (series.CurVolumeCount == series.MaxVolumeCount) return;
+
+        series.CurVolumeCount = series.MaxVolumeCount;
+        AppLog.CreateLogger<EditSeriesInfoWindow>()
+            .SeriesMarkedComplete(series.Titles[TsundokuLanguage.Romaji], series.MaxVolumeCount);
     }
 
     private void ChangeSeriesVolumeCounts()

--- a/Src/Views/EditSeriesInfoWindowLogging.cs
+++ b/Src/Views/EditSeriesInfoWindowLogging.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Tsundoku.Views;
+
+internal static partial class EditSeriesInfoWindowLogging
+{
+    [LoggerMessage(Level = LogLevel.Information, Message = "Marked {Title} complete ({VolumeCount} volumes)")]
+    public static partial void SeriesMarkedComplete(this ILogger logger, string title, uint volumeCount);
+}

--- a/Src/Views/MainWindow.axaml
+++ b/Src/Views/MainWindow.axaml
@@ -480,39 +480,145 @@
                     </Grid>
 
                     <!-- Row 4: Saved shelves (named filters) -->
-                    <ItemsControl Grid.Row="4"
-                                  Name="ShelfChipsRow"
-                                  ItemsSource="{CompiledBinding Shelves}">
-                        <ItemsControl.ItemsPanel>
+                    <ListBox Grid.Row="4"
+                             Name="ShelfChipsRow"
+                             Background="Transparent"
+                             BorderThickness="0"
+                             Padding="0"
+                             SelectionMode="Single,Toggle"
+                             ItemsSource="{CompiledBinding Shelves}"
+                             SelectedItem="{CompiledBinding SelectedShelf, Mode=TwoWay}">
+                        <ListBox.Styles>
+                            <Style Selector="ListBoxItem">
+                                <Setter Property="Padding" Value="0"/>
+                                <Setter Property="Margin" Value="0,0,6,6"/>
+                                <Setter Property="Background" Value="Transparent"/>
+                                <Setter Property="BorderThickness" Value="0"/>
+                                <Setter Property="CornerRadius" Value="14"/>
+                                <Setter Property="Cursor" Value="Hand"/>
+                                <Setter Property="Transitions">
+                                    <Transitions>
+                                        <BrushTransition Property="Background" Duration="0:0:0.18"/>
+                                    </Transitions>
+                                </Setter>
+                            </Style>
+                            <Style Selector="ListBoxItem /template/ ContentPresenter">
+                                <Setter Property="CornerRadius" Value="14"/>
+                                <Setter Property="Background" Value="Transparent"/>
+                                <Setter Property="BorderThickness" Value="0"/>
+                                <Setter Property="Padding" Value="0"/>
+                            </Style>
+                            <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter">
+                                <Setter Property="Background" Value="Transparent"/>
+                                <Setter Property="BorderThickness" Value="0"/>
+                            </Style>
+                            <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
+                                <Setter Property="Background" Value="Transparent"/>
+                                <Setter Property="BorderThickness" Value="0"/>
+                            </Style>
+                            <Style Selector="ListBoxItem:selected:focus /template/ ContentPresenter">
+                                <Setter Property="Background" Value="Transparent"/>
+                                <Setter Property="BorderThickness" Value="0"/>
+                            </Style>
+                            <Style Selector="ListBoxItem Border.shelf-chip">
+                                <Setter Property="Background" Value="{DynamicResource TsundokuMenuButtonBGColor}"/>
+                                <Setter Property="BorderBrush" Value="{DynamicResource TsundokuMenuButtonBorderColor}"/>
+                                <Setter Property="Transitions">
+                                    <Transitions>
+                                        <BrushTransition Property="Background" Duration="0:0:0.22"/>
+                                        <BrushTransition Property="BorderBrush" Duration="0:0:0.22"/>
+                                    </Transitions>
+                                </Setter>
+                            </Style>
+                            <Style Selector="ListBoxItem Border.shelf-chip TextBlock.shelf-text">
+                                <Setter Property="Foreground" Value="{DynamicResource TsundokuMenuButtonTextAndIconColor}"/>
+                                <Setter Property="Transitions">
+                                    <Transitions>
+                                        <BrushTransition Property="Foreground" Duration="0:0:0.22"/>
+                                    </Transitions>
+                                </Setter>
+                            </Style>
+                            <Style Selector="ListBoxItem Border.shelf-chip i|Icon.shelf-icon">
+                                <Setter Property="Foreground" Value="{DynamicResource TsundokuMenuButtonTextAndIconColor}"/>
+                                <Setter Property="Transitions">
+                                    <Transitions>
+                                        <BrushTransition Property="Foreground" Duration="0:0:0.22"/>
+                                    </Transitions>
+                                </Setter>
+                            </Style>
+                            <Style Selector="ListBoxItem:selected Border.shelf-chip">
+                                <Setter Property="Background" Value="{DynamicResource TsundokuMenuButtonTextAndIconColor}"/>
+                                <Setter Property="BorderBrush" Value="{DynamicResource TsundokuMenuButtonTextAndIconColor}"/>
+                            </Style>
+                            <Style Selector="ListBoxItem:selected Border.shelf-chip TextBlock.shelf-text">
+                                <Setter Property="Foreground" Value="{DynamicResource TsundokuMenuButtonBGColor}"/>
+                            </Style>
+                            <Style Selector="ListBoxItem:selected Border.shelf-chip i|Icon.shelf-icon">
+                                <Setter Property="Foreground" Value="{DynamicResource TsundokuMenuButtonBGColor}"/>
+                            </Style>
+                            <Style Selector="ListBoxItem Border.shelf-chip Button.shelf-close i|Icon.shelf-close-icon">
+                                <Setter Property="Foreground" Value="{DynamicResource TsundokuMenuButtonTextAndIconColor}"/>
+                                <Setter Property="Opacity" Value="0.55"/>
+                            </Style>
+                            <Style Selector="ListBoxItem Border.shelf-chip Button.shelf-close:pointerover">
+                                <Setter Property="Background" Value="{DynamicResource TsundokuMenuButtonBorderColor}"/>
+                            </Style>
+                            <Style Selector="ListBoxItem Border.shelf-chip Button.shelf-close:pointerover i|Icon.shelf-close-icon">
+                                <Setter Property="Opacity" Value="1"/>
+                            </Style>
+                            <Style Selector="ListBoxItem:selected Border.shelf-chip Button.shelf-close i|Icon.shelf-close-icon">
+                                <Setter Property="Foreground" Value="{DynamicResource TsundokuMenuButtonBGColor}"/>
+                                <Setter Property="Opacity" Value="0.7"/>
+                            </Style>
+                            <Style Selector="ListBoxItem:selected Border.shelf-chip Button.shelf-close:pointerover">
+                                <Setter Property="Background" Value="{DynamicResource TsundokuMenuButtonBGColor}"/>
+                            </Style>
+                            <Style Selector="ListBoxItem:selected Border.shelf-chip Button.shelf-close:pointerover i|Icon.shelf-close-icon">
+                                <Setter Property="Foreground" Value="{DynamicResource TsundokuMenuButtonTextAndIconColor}"/>
+                                <Setter Property="Opacity" Value="1"/>
+                            </Style>
+                        </ListBox.Styles>
+                        <ListBox.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <WrapPanel Orientation="Horizontal" ItemSpacing="6" LineSpacing="6"/>
+                                <WrapPanel Orientation="Horizontal"/>
                             </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.ItemTemplate>
                             <DataTemplate x:DataType="m:SavedShelf">
-                                <Button Padding="10,4"
-                                        FontSize="12"
-                                        FontWeight="Bold"
+                                <Border Classes="shelf-chip"
+                                        BorderThickness="2"
                                         CornerRadius="14"
-                                        Cursor="Hand"
-                                        Theme="{StaticResource MenuButton}"
-                                        Click="ShelfClicked"
-                                        ToolTip.Tip="{CompiledBinding Query}"
-                                        Tag="{CompiledBinding}">
+                                        Padding="10,4,4,4"
+                                        ToolTip.Tip="{CompiledBinding Query}">
                                     <StackPanel Orientation="Horizontal" Spacing="6">
-                                        <i:Icon Value="{CompiledBinding IconKey}" FontSize="11" VerticalAlignment="Center"/>
-                                        <TextBlock Text="{CompiledBinding Name}" VerticalAlignment="Center"/>
+                                        <i:Icon Classes="shelf-icon" Value="{CompiledBinding IconKey}" FontSize="11" VerticalAlignment="Center"/>
+                                        <TextBlock Classes="shelf-text" Text="{CompiledBinding Name}" FontSize="12" FontWeight="Bold" VerticalAlignment="Center"/>
+                                        <Button Classes="shelf-close"
+                                                Tag="{CompiledBinding}"
+                                                Click="DeleteShelf"
+                                                ToolTip.Tip="Delete shelf"
+                                                Width="18" Height="18"
+                                                Padding="0"
+                                                Margin="2,0,0,0"
+                                                CornerRadius="9"
+                                                VerticalAlignment="Center"
+                                                HorizontalAlignment="Center"
+                                                Background="Transparent"
+                                                BorderThickness="0"
+                                                Cursor="Hand">
+                                            <i:Icon Classes="shelf-close-icon" Value="fa7-solid fa7-xmark" FontSize="11"/>
+                                        </Button>
                                     </StackPanel>
-                                    <Button.ContextMenu>
+                                    <Border.ContextMenu>
                                         <ContextMenu>
                                             <MenuItem Header="Rename…" Click="RenameShelf" Tag="{CompiledBinding}"/>
                                             <MenuItem Header="Delete" Click="DeleteShelf" Tag="{CompiledBinding}"/>
                                         </ContextMenu>
-                                    </Button.ContextMenu>
-                                </Button>
+                                    </Border.ContextMenu>
+                                </Border>
                             </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                 </Grid>
             </Border>
 

--- a/Src/Views/MainWindow.axaml
+++ b/Src/Views/MainWindow.axaml
@@ -83,6 +83,16 @@
                            FontSize="13" FontWeight="Bold"
                            HorizontalAlignment="Center"
                            Foreground="{DynamicResource TsundokuSearchBarTextColor}"/>
+                <Button Name="SaveAsShelfButton"
+                        Content="Save as shelf…"
+                        HorizontalAlignment="Center"
+                        Margin="0,8,0,0"
+                        Padding="14,6"
+                        FontSize="12"
+                        FontWeight="Bold"
+                        Cursor="Hand"
+                        Theme="{StaticResource MenuButton}"
+                        Click="SaveCurrentFilterAsShelf"/>
             </StackPanel>
         </Panel>
 
@@ -227,7 +237,7 @@
                     BorderBrush="{DynamicResource TsundokuDividerColor}"
                     BorderThickness="0,0,0,2"
                     Padding="24,12">
-                <Grid RowDefinitions="Auto,8,Auto">
+                <Grid RowDefinitions="Auto,8,Auto,8,Auto">
                     <!-- Row 0: User Area + Search -->
                     <Grid ColumnDefinitions="Auto,*">
                         <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
@@ -468,6 +478,41 @@
 
                         </StackPanel>
                     </Grid>
+
+                    <!-- Row 4: Saved shelves (named filters) -->
+                    <ItemsControl Grid.Row="4"
+                                  Name="ShelfChipsRow"
+                                  ItemsSource="{CompiledBinding Shelves}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal" ItemSpacing="6" LineSpacing="6"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="m:SavedShelf">
+                                <Button Padding="10,4"
+                                        FontSize="12"
+                                        FontWeight="Bold"
+                                        CornerRadius="14"
+                                        Cursor="Hand"
+                                        Theme="{StaticResource MenuButton}"
+                                        Click="ShelfClicked"
+                                        ToolTip.Tip="{CompiledBinding Query}"
+                                        Tag="{CompiledBinding}">
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <i:Icon Value="{CompiledBinding IconKey}" FontSize="11" VerticalAlignment="Center"/>
+                                        <TextBlock Text="{CompiledBinding Name}" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                    <Button.ContextMenu>
+                                        <ContextMenu>
+                                            <MenuItem Header="Rename…" Click="RenameShelf" Tag="{CompiledBinding}"/>
+                                            <MenuItem Header="Delete" Click="DeleteShelf" Tag="{CompiledBinding}"/>
+                                        </ContextMenu>
+                                    </Button.ContextMenu>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </Grid>
             </Border>
 

--- a/Src/Views/MainWindow.axaml.cs
+++ b/Src/Views/MainWindow.axaml.cs
@@ -584,14 +584,6 @@ KeyDown += async (s, e) =>
         }
     }
 
-    private void ShelfClicked(object sender, RoutedEventArgs args)
-    {
-        if (sender is Button { Tag: SavedShelf shelf })
-        {
-            ViewModel.SelectedShelf = shelf;
-        }
-    }
-
     private async void RenameShelf(object sender, RoutedEventArgs args)
     {
         if (sender is not MenuItem { Tag: SavedShelf shelf }) return;
@@ -617,7 +609,9 @@ KeyDown += async (s, e) =>
 
     private async void DeleteShelf(object sender, RoutedEventArgs args)
     {
-        if (sender is not MenuItem { Tag: SavedShelf shelf }) return;
+        if (sender is not Control { Tag: SavedShelf shelf }) return;
+
+        args.Handled = true;
 
         bool confirmed = await _popupDialogService.ConfirmAsync(
             "Delete Shelf",

--- a/Src/Views/MainWindow.axaml.cs
+++ b/Src/Views/MainWindow.axaml.cs
@@ -78,11 +78,12 @@ public sealed partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
             // Back to top button visibility based on scroll offset
             CollectionPane.GetObservable(ScrollViewer.OffsetProperty)
-                .Subscribe(offset =>
+                .Select(o => (Show: o.Y > 300, Visible: o.Y > 50))
+                .DistinctUntilChanged()
+                .Subscribe(s =>
                 {
-                    bool show = offset.Y > 300;
-                    BackToTopButton.Opacity = show ? 1 : 0;
-                    BackToTopButton.IsVisible = offset.Y > 50;
+                    BackToTopButton.Opacity = s.Show ? 1 : 0;
+                    BackToTopButton.IsVisible = s.Visible;
                 })
                 .DisposeWith(disposables);
 
@@ -104,86 +105,10 @@ public sealed partial class MainWindow : ReactiveWindow<MainWindowViewModel>
                     _apiHealthCheckService.IsMangaDexAvailable,
                     (aniList, mangaDex) => (AniList: aniList, MangaDex: mangaDex))
                 .ObserveOn(RxSchedulers.MainThreadScheduler)
-                .Subscribe(async status =>
-                {
-                    bool aniListChanged = status.AniList == _aniListDown;
-                    bool mangaDexChanged = status.MangaDex == _mangaDexDown;
-
-                    if (!aniListChanged && !mangaDexChanged) return;
-
-                    bool wasAniListDown = _aniListDown;
-                    bool wasMangaDexDown = _mangaDexDown;
-                    _aniListDown = !status.AniList;
-                    _mangaDexDown = !status.MangaDex;
-
-                    // Disable add series button based on AniList status
-                    AddNewSeriesButton.IsEnabled = status.AniList;
-
-                    // Build message for newly down services
-                    if (_aniListDown && !wasAniListDown && _mangaDexDown && !wasMangaDexDown)
-                    {
-                        await _popupDialogService.ShowAsync(
-                            "API Outage",
-                            "fa7-solid fa7-triangle-exclamation",
-                            "AniList and MangaDex APIs are currently unavailable. Adding new series, refreshing series, and importing from Libib or Goodreads have been disabled until AniList is back online.",
-                            this);
-                    }
-                    else if (_aniListDown && !wasAniListDown && !_mangaDexDown)
-                    {
-                        bool enableAdd = await _popupDialogService.ConfirmAsync(
-                            "API Outage",
-                            "fa7-solid fa7-triangle-exclamation",
-                            "AniList API is currently unavailable. Refreshing series and importing from Libib or Goodreads have been disabled.\n\nMangaDex is online — would you like to enable adding new series via MangaDex?",
-                            this);
-
-                        if (enableAdd)
-                        {
-                            AddNewSeriesButton.IsEnabled = true;
-                        }
-                    }
-                    else if (_aniListDown && !wasAniListDown && _mangaDexDown)
-                    {
-                        await _popupDialogService.ShowAsync(
-                            "API Outage",
-                            "fa7-solid fa7-triangle-exclamation",
-                            "AniList API is currently unavailable. Adding new series, refreshing series, and importing from Libib or Goodreads have been disabled until it is back online.",
-                            this);
-                    }
-                    else if (_mangaDexDown && !wasMangaDexDown)
-                    {
-                        await _popupDialogService.ShowAsync(
-                            "API Outage",
-                            "fa7-solid fa7-triangle-exclamation",
-                            "MangaDex API is currently unavailable. You can still add and refresh series using AniList.",
-                            this);
-                    }
-
-                    // Notify when services come back online
-                    if (!_aniListDown && wasAniListDown && !_mangaDexDown && wasMangaDexDown)
-                    {
-                        await _popupDialogService.ShowAsync(
-                            "APIs Restored",
-                            "fa7-solid fa7-circle-check",
-                            "AniList and MangaDex APIs are back online. All features have been re-enabled.",
-                            this);
-                    }
-                    else if (!_aniListDown && wasAniListDown)
-                    {
-                        await _popupDialogService.ShowAsync(
-                            "API Restored",
-                            "fa7-solid fa7-circle-check",
-                            "AniList API is back online. All features have been re-enabled.",
-                            this);
-                    }
-                    else if (!_mangaDexDown && wasMangaDexDown)
-                    {
-                        await _popupDialogService.ShowAsync(
-                            "API Restored",
-                            "fa7-solid fa7-circle-check",
-                            "MangaDex API is back online.",
-                            this);
-                    }
-                })
+                .SelectMany(status => Observable.FromAsync(ct => HandleApiStatusChangeAsync(status, ct)))
+                .Subscribe(
+                    onNext: static _ => { },
+                    onError: ex => LOGGER.Error(ex, "API status handler faulted"))
                 .DisposeWith(disposables);
 
             _apiHealthCheckService.Start();
@@ -234,15 +159,15 @@ KeyDown += async (s, e) =>
         {
             if (_isShuttingDown) return;
             _isShuttingDown = true;
+            App.IsShuttingDown = true;
 
             ViewModel.SaveOnClose();
 
-            // Hide all children so their Closing handlers won't cancel
             foreach (Window child in (Window[])[_newSeriesWindow, _userSettingsWindow, _themeSettingsWindow, _priceAnalysisWindow, _collectionStatsWindow, _userNotesWindow])
             {
                 if (child.IsVisible)
                 {
-                    child.Hide();
+                    child.Close();
                 }
             }
 
@@ -546,6 +471,163 @@ KeyDown += async (s, e) =>
         {
             curSeries.CurVolumeCount -= 1;
             LOGGER.Info("Removed 1 Volume from {title}", curSeries.Titles[TsundokuLanguage.Romaji]);
+        }
+    }
+
+    private async Task HandleApiStatusChangeAsync((bool AniList, bool MangaDex) status, CancellationToken cancellationToken)
+    {
+        bool aniListChanged = status.AniList == _aniListDown;
+        bool mangaDexChanged = status.MangaDex == _mangaDexDown;
+
+        if (!aniListChanged && !mangaDexChanged) return;
+
+        bool wasAniListDown = _aniListDown;
+        bool wasMangaDexDown = _mangaDexDown;
+        _aniListDown = !status.AniList;
+        _mangaDexDown = !status.MangaDex;
+
+        AddNewSeriesButton.IsEnabled = status.AniList;
+
+        if (_aniListDown && !wasAniListDown && _mangaDexDown && !wasMangaDexDown)
+        {
+            await _popupDialogService.ShowAsync(
+                "API Outage",
+                "fa7-solid fa7-triangle-exclamation",
+                "AniList and MangaDex APIs are currently unavailable. Adding new series, refreshing series, and importing from Libib or Goodreads have been disabled until AniList is back online.",
+                this);
+        }
+        else if (_aniListDown && !wasAniListDown && !_mangaDexDown)
+        {
+            bool enableAdd = await _popupDialogService.ConfirmAsync(
+                "API Outage",
+                "fa7-solid fa7-triangle-exclamation",
+                "AniList API is currently unavailable. Refreshing series and importing from Libib or Goodreads have been disabled.\n\nMangaDex is online — would you like to enable adding new series via MangaDex?",
+                this);
+
+            if (enableAdd)
+            {
+                AddNewSeriesButton.IsEnabled = true;
+            }
+        }
+        else if (_aniListDown && !wasAniListDown && _mangaDexDown)
+        {
+            await _popupDialogService.ShowAsync(
+                "API Outage",
+                "fa7-solid fa7-triangle-exclamation",
+                "AniList API is currently unavailable. Adding new series, refreshing series, and importing from Libib or Goodreads have been disabled until it is back online.",
+                this);
+        }
+        else if (_mangaDexDown && !wasMangaDexDown)
+        {
+            await _popupDialogService.ShowAsync(
+                "API Outage",
+                "fa7-solid fa7-triangle-exclamation",
+                "MangaDex API is currently unavailable. You can still add and refresh series using AniList.",
+                this);
+        }
+
+        if (!_aniListDown && wasAniListDown && !_mangaDexDown && wasMangaDexDown)
+        {
+            await _popupDialogService.ShowAsync(
+                "APIs Restored",
+                "fa7-solid fa7-circle-check",
+                "AniList and MangaDex APIs are back online. All features have been re-enabled.",
+                this);
+        }
+        else if (!_aniListDown && wasAniListDown)
+        {
+            await _popupDialogService.ShowAsync(
+                "API Restored",
+                "fa7-solid fa7-circle-check",
+                "AniList API is back online. All features have been re-enabled.",
+                this);
+        }
+        else if (!_mangaDexDown && wasMangaDexDown)
+        {
+            await _popupDialogService.ShowAsync(
+                "API Restored",
+                "fa7-solid fa7-circle-check",
+                "MangaDex API is back online.",
+                this);
+        }
+    }
+
+    private async void SaveCurrentFilterAsShelf(object sender, RoutedEventArgs args)
+    {
+        if (string.IsNullOrWhiteSpace(ViewModel.FilterBuilder.SynthesizedQuery))
+        {
+            await _popupDialogService.ShowAsync(
+                "Empty Filter",
+                "fa7-solid fa7-circle-exclamation",
+                "Add at least one filter chip before saving as a shelf.",
+                this);
+            return;
+        }
+
+        string? name = await _popupDialogService.InputAsync(
+            "Save Filter as Shelf",
+            "fa7-solid fa7-bookmark",
+            "Name for this shelf:",
+            this);
+
+        if (string.IsNullOrWhiteSpace(name)) return;
+
+        try
+        {
+            ViewModel.SaveCurrentFilterAsShelf(name);
+            AdvancedSearchPopup.IsVisible = false;
+        }
+        catch (Exception ex)
+        {
+            LOGGER.Warn(ex, "Failed to save shelf");
+            await _popupDialogService.ShowAsync("Invalid Name", "fa7-solid fa7-triangle-exclamation", ex.Message, this);
+        }
+    }
+
+    private void ShelfClicked(object sender, RoutedEventArgs args)
+    {
+        if (sender is Button { Tag: SavedShelf shelf })
+        {
+            ViewModel.SelectedShelf = shelf;
+        }
+    }
+
+    private async void RenameShelf(object sender, RoutedEventArgs args)
+    {
+        if (sender is not MenuItem { Tag: SavedShelf shelf }) return;
+
+        string? newName = await _popupDialogService.InputAsync(
+            "Rename Shelf",
+            "fa7-solid fa7-pen-to-square",
+            $"New name for '{shelf.Name}':",
+            this);
+
+        if (string.IsNullOrWhiteSpace(newName)) return;
+
+        try
+        {
+            ViewModel.RenameShelf(shelf, newName);
+        }
+        catch (Exception ex)
+        {
+            LOGGER.Warn(ex, "Failed to rename shelf");
+            await _popupDialogService.ShowAsync("Invalid Name", "fa7-solid fa7-triangle-exclamation", ex.Message, this);
+        }
+    }
+
+    private async void DeleteShelf(object sender, RoutedEventArgs args)
+    {
+        if (sender is not MenuItem { Tag: SavedShelf shelf }) return;
+
+        bool confirmed = await _popupDialogService.ConfirmAsync(
+            "Delete Shelf",
+            "fa7-solid fa7-trash-can",
+            $"Delete shelf '{shelf.Name}'?",
+            this);
+
+        if (confirmed)
+        {
+            ViewModel.DeleteShelf(shelf);
         }
     }
 }

--- a/Src/Views/PriceAnalysisWindow.axaml
+++ b/Src/Views/PriceAnalysisWindow.axaml
@@ -125,25 +125,14 @@
 						<TextBlock Grid.Row="0" Text="WEBSITES" Classes="section-title" Margin="0,0,0,4"
 								   ToolTip.Tip="{CompiledBinding WebsitesToolTipText}"
 								   ToolTip.IsEnabled="{CompiledBinding WebsitesToolTipText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-						<ListBox x:Name="WebsiteSelector"
-								 Grid.Row="1"
-								 Theme="{StaticResource QueryListBox}"
-								 SelectionMode="Multiple,Toggle"
-                                 SelectionChanged="WebsiteSelectionChanged"
-								 SelectedItems="{CompiledBinding SelectedWebsites}">
-							<ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="Amazon USA" ToolTip.Tip="America"/>
-							<ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="Books-A-Million" ToolTip.Tip="America"/>
-                            <ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="Crunchyroll" ToolTip.Tip="America"/>
-                            <ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="Forbidden Planet" ToolTip.Tip="Britain"/>
-							<ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="InStockTrades" ToolTip.Tip="America"/>
-							<ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="Kinokuniya USA" ToolTip.Tip="America"/>
-                            <ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="MangaMate" ToolTip.Tip="Australia"/>
-                            <ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="MerryManga" ToolTip.Tip="America"/>
-							<ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="RobertsAnimeCornerStore" ToolTip.Tip="America"/>
-                            <ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="SciFier" ToolTip.Tip="America | Britain | Canada | Europe | Australia"/>
-                            <ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="SpeedyHen" ToolTip.Tip="Britain"/>
-                            <ListBoxItem Theme="{StaticResource QueryListBoxItem}" Content="TravellingMan" ToolTip.Tip="Britain"/>
-                        </ListBox>
+                            <ListBox x:Name="WebsiteSelector"
+                                     Grid.Row="1"
+                                     Theme="{StaticResource QueryListBox}"
+                                     SelectionMode="Multiple,Toggle"
+                                     SelectionChanged="WebsiteSelectionChanged"
+                                     ItemsSource="{CompiledBinding AvailableWebsites}"
+                                     ItemContainerTheme="{StaticResource QueryListBoxItem}"
+                                     SelectedItems="{CompiledBinding SelectedWebsites}"/>
 					</Grid>
 
 					<!-- Start Analysis Button -->

--- a/Src/Views/PriceAnalysisWindow.axaml.cs
+++ b/Src/Views/PriceAnalysisWindow.axaml.cs
@@ -20,13 +20,14 @@ public sealed partial class PriceAnalysisWindow : ReactiveWindow<PriceAnalysisVi
     private static readonly Logger LOGGER = LogManager.GetCurrentClassLogger();
     public bool IsOpen { get; set; }
     public bool Manga;
-    public readonly MasterScrape _scrape = new(StockStatusFilter.EXCLUDE_NONE_FILTER);
+    public readonly MasterScrape _scrape = new(StockStatusFilter.EXCLUDE_NONE_FILTER) { SkipUnavailableSites = true };
     private Region CurRegion;
 
     public PriceAnalysisWindow(PriceAnalysisViewModel viewModel)
     {
         InitializeComponent();
         ViewModel = viewModel;
+        CurRegion = viewModel.CurrentUser.Region;
 
         this.ConfigureHideOnClose(onClosing: () => SearchTextBox.Text = string.Empty);
 
@@ -77,7 +78,7 @@ public sealed partial class PriceAnalysisWindow : ReactiveWindow<PriceAnalysisVi
         string scrapeScenario = string.Empty;
         try
         {
-            HashSet<Website> websiteList = [.. ViewModel.SelectedWebsites.AsValueEnumerable().Select(website => MangaAndLightNovelWebScrape.Helpers.GetWebsiteFromString(website.Content?.ToString() ?? string.Empty))];
+            HashSet<Website> websiteList = [.. ViewModel.SelectedWebsites.AsValueEnumerable().Select(MangaAndLightNovelWebScrape.Helpers.GetWebsiteFromString)];
 
             scrapeScenario = $"\"{SearchTextBox.Text}\" on {_scrape.Browser} Browser w/ Region = \"{_scrape.Region}\" & \"{StockFilterSelector.SelectedItem as string} Filter\" & Websites = [{string.Join(", ", websiteList)}] & Memberships = ({string.Join(" & ", ViewModel.CurrentUser.Memberships)})";
 
@@ -87,8 +88,13 @@ public sealed partial class PriceAnalysisWindow : ReactiveWindow<PriceAnalysisVi
             _scrape.Browser = MangaAndLightNovelWebScrape.Helpers.GetBrowserFromString((BrowserSelector.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? string.Empty);
             _scrape.Region = ViewModel.CurrentUser.Region;
             _scrape.Filter = MangaAndLightNovelWebScrape.Helpers.GetStockStatusFilterFromString(StockFilterSelector.SelectedItem as string);
-            _scrape.IsBooksAMillionMember = ViewModel.CurrentUser.Memberships[BooksAMillion.TITLE];
-            _scrape.IsKinokuniyaUSAMember = ViewModel.CurrentUser.Memberships[KinokuniyaUSA.TITLE];
+
+            Membership memberships = Membership.None;
+            if (ViewModel.CurrentUser.Memberships.TryGetValue(BooksAMillion.TITLE, out bool bam) && bam)
+                memberships |= Membership.BooksAMillion;
+            if (ViewModel.CurrentUser.Memberships.TryGetValue(KinokuniyaUSA.TITLE, out bool kino) && kino)
+                memberships |= Membership.KinokuniyaUSA;
+            _scrape.Memberships = memberships;
 
             LOGGER.Info("Started Scrape For {Scenario}", scrapeScenario);
 
@@ -101,6 +107,34 @@ public sealed partial class PriceAnalysisWindow : ReactiveWindow<PriceAnalysisVi
 
             ViewModel.AnalyzedList.Clear();
             ViewModel.AnalyzedList.AddRange(_scrape.GetResults());
+
+            foreach ((Website site, Exception err) in _scrape.Errors)
+            {
+                if (err is SiteUnavailableException)
+                {
+                    LOGGER.Info("{Site} skipped — unreachable", site);
+                }
+                else if (err is SiteScrapeException)
+                {
+                    LOGGER.Warn(err, "{Site} scrape failed", site);
+                }
+                else
+                {
+                    LOGGER.Warn(err, "{Site} reported an unexpected error", site);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            LOGGER.Info("Price Analysis Scrape {Scenario} was cancelled", scrapeScenario);
+        }
+        catch (ScrapeBrowserLaunchException ex)
+        {
+            LOGGER.Error(ex, "Playwright failed to launch — JavaScript-rendered sites cannot run");
+        }
+        catch (ArgumentException ex)
+        {
+            LOGGER.Warn(ex, "Price Analysis Scrape {Scenario} rejected (bad input)", scrapeScenario);
         }
         catch (Exception ex)
         {
@@ -140,7 +174,7 @@ public sealed partial class PriceAnalysisWindow : ReactiveWindow<PriceAnalysisVi
     private void WebsiteSelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (sender is not ListBox listBox) { return; }
-        string[] list = [.. listBox.SelectedItems.AsValueEnumerable().Cast<ListBoxItem>().Select(x => x.Content?.ToString() ?? string.Empty)];
+        string[] list = [.. listBox.SelectedItems.AsValueEnumerable().Cast<string>()];
         ViewModel.WebsitesSelected = list.Length != 0 && MangaAndLightNovelWebScrape.Helpers.IsWebsiteListValid(CurRegion, list);
     }
 

--- a/Src/Views/ThemeSettingsWindow.axaml.cs
+++ b/Src/Views/ThemeSettingsWindow.axaml.cs
@@ -54,6 +54,14 @@ public sealed partial class CollectionThemeWindow : ReactiveWindow<ThemeSettings
 
         Closing += (s, e) =>
         {
+            if (App.IsShuttingDown)
+            {
+                _themeObserveDisposable?.Dispose();
+                _themeObserveDisposable = null;
+                IsOpen = false;
+                return;
+            }
+
             if (IsOpen)
             {
                 _themeObserveDisposable?.Dispose();


### PR DESCRIPTION
﻿## Summary

Ships the v2.3.0 release: introduces Smart Shelves (saved filter chips), revamps the Edit Series window with a full icon toolbar and series-to-series navigation, lets the Add Series flow accept AniList/MangaDex URLs, upgrades the price scraper to v6 with region-filtered sites and resilient per-site error handling, and migrates the logging stack onto source-generated `Microsoft.Extensions.Logging` while tightening editorconfig analyzer enforcement.

## Changes

### Smart Shelves
- New `SavedShelf` model (Name / Query / IconKey / Guid Id) persisted via a new `UserService` API (`AddShelf`, `RemoveShelf`, `RenameShelf`, `SavedShelves` observable collection).
- UserData schema bumped to **v6.4** with a migration that seeds `SavedShelves` on existing profiles.
- Main window gains a chip row under the toolbar: click to apply, click again to deselect, right-click to rename, × to delete; the active shelf is visually highlighted via dynamic-resource theming and brush transitions.
- Advanced search popup now has a "Save as shelf…" button that captures the current synthesized filter expression behind a name prompt.

### Add Series
- `SeriesUrlParser` detects AniList (`anilist.co/manga/<id>`) and MangaDex (`mangadex.org/title/<uuid>`) links and rewrites the input to the bare ID.
- Detected source surfaces as a "Detected: AniList/MangaDex" pill next to the field label.
- Title input is now fixed-height (90px) with a vertical scrollbar instead of growing on overflow.

### Edit Series
- Header replaces the single "Delete" button with an icon toolbar: previous/next series, open link, favorite, refresh, save, mark complete, delete.
- Previous/Next traverse the currently filtered/sorted main-window collection; `HasPrevious`/`HasNext` keep the buttons disabled at the ends.
- Header lists every saved title (Romaji, English, Japanese, Native, …) on its own row with key + value layout.
- "Mark Complete" sets `CurVolumeCount = MaxVolumeCount` (with a guard popup when max is unknown).
- Notes textbox grows to 220×560 and inner grids widen to match.

### Price Analysis
- Upgraded `MangaAndLightNovelWebScrape` to **6.0.0**; added All Star Comics (AU), Kings Comics (AU), OK Comics (UK), MangaMart (US), and removed retired SpeedyHen.
- Website list is now data-bound and rebuilt from `Helpers.GetRegionWebsiteList(region)` whenever the user's region changes — only sites that ship the selected region are shown.
- `MasterScrape` runs with `SkipUnavailableSites = true`, and per-site `SiteUnavailableException` / `SiteScrapeException` / `OperationCanceledException` / `ScrapeBrowserLaunchException` are logged individually instead of aborting the whole scrape.
- Memberships migrated from per-site bool flags to the new `Membership` flags enum.

### Logging
- Added DI-registered `Microsoft.Extensions.Logging` bridged to NLog via `NLog.Extensions.Logging`.
- New `AppLog` static accessor exposes `ILoggerFactory` to non-DI call sites.
- `ApiHealthCheckService` and `EditSeriesInfoWindow` converted to source-generated `[LoggerMessage]` extension classes (`ApiHealthCheckServiceLogging`, `EditSeriesInfoWindowLogging`).
- New NLog rule suppresses `System.Net.Http.HttpClient.*` Trace/Info chatter; existing rules updated to fully-qualified `NLog.LogLevel`.

### Shell / lifecycle
- New `App.IsShuttingDown` flag; `WindowHelper.ConfigureHideOnClose` and `ThemeSettingsWindow` honor it so secondary windows actually close on app exit instead of being cancelled by the hide-on-close handler. Main window now `Close()`s children during shutdown.
- API status handler refactored from a giant `Subscribe` lambda into `HandleApiStatusChangeAsync` and serialized through `SelectMany(FromAsync)`.
- Back-to-top button visibility now flips through `DistinctUntilChanged` to skip redundant property writes.

### Misc
- `SeriesCardDisplay` fade-in lengthened (650ms → 950ms) and hold cue shortened (0.3 → 0.2) so filter/shelf toggles cross-fade more softly.
- `.editorconfig` rewritten: `root = true`, enables `IDE0005` and the full "can be simplified" IDE rule set as warnings, codifies PascalCase constants / `_camelCase` private fields, and bans `var`. `Directory.Build.props` enables `EnforceCodeStyleInBuild`, `AnalysisLevel=latest`, and `TieredPGO`.
- `changelog.json` and a new `RELEASE_NOTES_v2.3.0.md` document the release.

## Package Bumps

| Package | From | To |
|---------|------|----|
| Avalonia.Controls.ColorPicker | 12.0.3 | 12.0.5 |
| Avalonia.Desktop | 12.0.3 | 12.0.5 |
| Avalonia.Diagnostics | 11.3.15 | 11.3.18 |
| Avalonia.Themes.Fluent | 12.0.3 | 12.0.5 |
| Avalonia.Controls.DataGrid | 12.0.0 | 12.0.1 |
| Avalonia.Headless.NUnit | 12.0.3 | 12.0.5 |
| ReactiveUI.Avalonia | 12.0.1 | 12.0.3 |
| ReactiveUI.SourceGenerators | 2.6.30 | 3.1.0 |
| MangaAndLightNovelWebScrape | 5.0.2 | 6.0.0 |
| Microsoft.Extensions.Http | 10.0.8 | 10.0.9 |
| Microsoft.Extensions.Logging | — | 10.0.9 (added) |
| NLog.Extensions.Logging | — | 6.1.3 (added) |
| Optris.Icons.Avalonia.FontAwesome7 | 12.0.6 | 12.0.7 |
| System.Drawing.Common | 10.0.8 | 10.0.9 |
| Microsoft.NET.Test.Sdk | 18.5.1 | 18.7.0 |
| NUnit | 4.6.0 | 4.6.1 |
| NUnit.Analyzers | 4.13.0 | 4.14.0 |
| Microsoft.Windows.SDK.BuildTools | 10.0.28000.1839 | 10.0.28000.2270 |

## Test Plan

- [ ] Save, apply, rename, and delete a Smart Shelf; restart the app and confirm shelves persist (schema v6.4 migration runs cleanly on an existing UserData.json).
- [ ] Paste both an AniList and a MangaDex series URL into Add Series and confirm the field auto-fills the ID and shows the "Detected" pill.
- [ ] Run a Price Analysis after switching regions and verify only region-appropriate sites appear and that an unreachable site is logged + skipped without aborting the run.

## Notes

- `User.SavedShelves` is new — existing profiles get an empty array via the v6.4 migration; rolling back to an older build will drop saved shelves but is otherwise safe.
- `MangaAndLightNovelWebScrape` 5 → 6 is a major bump; the `Memberships` API changed from per-site booleans to a `[Flags]` enum (already adapted in `PriceAnalysisWindow`).